### PR TITLE
Embed production Firebase configuration script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,12 @@
+// Production Firebase configuration for God's Pride Group of Schools.
+// This script exposes the config on window so the module loader can
+// initialize Firebase services without additional setup.
+window.__FIREBASE_CONFIG__ = {
+  apiKey: "AIzaSyB3-eNYchzU1gdDlpzQa6eaupzjwvkUK2Y",
+  authDomain: "god-s-pride-school.firebaseapp.com",
+  projectId: "god-s-pride-school",
+  storageBucket: "god-s-pride-school.firebasestorage.app",
+  messagingSenderId: "138260092435",
+  appId: "1:138260092435:web:f18fc9be6171ae165891e6",
+  measurementId: "G-F8DLXEHBFB",
+};

--- a/index.html
+++ b/index.html
@@ -13,38 +13,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
-  <script>
-    $(document).ready(function(){
-      $('.testimonial-carousel').slick({
-        dots: true,
-        infinite: true,
-        speed: 500,
-        slidesToShow: 2,
-        slidesToScroll: 1,
-        responsive: [
-          {
-            breakpoint: 768,
-            settings: {
-              slidesToShow: 1
-            }
-          }
-        ]
-      });
-    });
-  </script>
 </head>
 
 <body>
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img data-storage-field="leftLogoPath" data-placeholder="logo_left.JPG" src="" alt="Left Logo">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="hero-copy">
+      <h1 data-firestore-field="hero-title">GOD'S PRIDE GROUP OF SCHOOLS</h1>
+      <p class="slogan" data-firestore-field="hero-slogan">Building Spiritual, Moral and Academic Excellence on a Firm
+        Foundation</p>
+      <div id="hero-loading" class="loading-message" hidden>Loading school profile...</div>
+      <div id="hero-error" class="error-message" hidden></div>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img data-storage-field="rightLogoPath" data-placeholder="logo_right.JPG" src="" alt="Right Logo">
     </div>
   </header>
 
@@ -62,27 +46,12 @@
 
   <section class="image-carousel">
     <div id="myCarousel" class="carousel slide" data-ride="carousel">
-      <ol class="carousel-indicators">
-        <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
-        <li data-target="#myCarousel" data-slide-to="1"></li>
-        <li data-target="#myCarousel" data-slide-to="2"></li>
-      </ol>
-  
-      <div class="carousel-inner">
-        <div class="carousel-item active">
-          <img src="carousel-image4.png" class="d-block w-100" alt="Image 1">
-        </div>
-        <div class="carousel-item">
-          <img src="carousel-image1.jpg" class="d-block w-100" alt="Image 2">
-        </div>
-        <div class="carousel-item">
-          <img src="carousel-image2.jpg" class="d-block w-100" alt="Image 3">
-        </div>
-        <div class="carousel-item">
-          <img src="carousel-image3.jpg" class="d-block w-100" alt="Image 4">
-        </div>
-      </div>
-  
+      <ol class="carousel-indicators"></ol>
+
+      <div class="carousel-inner"></div>
+      <div id="carousel-loading" class="loading-message" hidden>Loading highlights...</div>
+      <div id="carousel-error" class="error-message" hidden></div>
+
       <a class="carousel-control-prev" href="#myCarousel" role="button" data-slide="prev">
         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
         <span class="sr-only">Previous</span>
@@ -95,137 +64,26 @@
   </section>
 
   <div class="container1">
-    <section class"intro1">
-      <h2 class="section-title">God's Pride Group of Schools</h2>
-      <div class="scrolling-text">The Home Of Godly Global Champions</div>
+    <section class="intro1">
+      <h2 class="section-title" data-firestore-field="hero-subtitle">God's Pride Group of Schools</h2>
+      <div class="scrolling-text" data-firestore-field="hero-tagline">The Home Of Godly Global Champions</div>
     </section>
   </div>
   
   <div class="container">
     <section class="announcement">
       <h2 class="section-title">Latest Announcements</h2>
-      <div class="announcement-cards">
-        <div class="announcement-card">
-          <img src="announcement-image1.jpeg" alt="Announcement 1">
-          <h3>ADMISSIONS NOW OPEN!!!</h3>
-          <div class="scrolling-text">
-            <p><strong>Admissions Are Open for God's Pride School!</strong></p>
-          </div>
-          <a href="#" class="read-more-link">Read More</a>
-          <div class="expanded-content">
-            <p>Admissions Are Open at God's Pride School! Explore an educational journey grounded in faith,
-              excellence, and innovation at God's Pride School. As a mandate and a God-given institution,
-              we are driven by a powerful vision and mission: to raise a generation of new academics firmly
-              founded on Godly values.</p>
-          </div>
-        </div>
-        <div class="announcement-card">
-          <img src="announcement-image2.jpeg" alt="Announcement 2">
-          <h3>2024 Summer Splash !!!</h3>
-          <div class="scrolling-text">
-            <p><strong>🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞</strong></p>
-          </div>
-          <a href="#" class="read-more-link">Read More</a>
-          <div class="expanded-content">
-            <p><strong>🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞</strong></p>
-            <p>Empowering Kids and Teens to Explore the World of Coding and Artificial Intelligence Through Hands-on Activities and Interactive Sessions organized by DSN.</p>
-            <p><strong>Highlights:</strong></p>
-            <ul>
-              <li>Dear Parent,</li>
-              <br/><br/>
-              <li>We are thrilled to invite your child to the FREE AI Career Development Event for Kids and Teens.</li>
-              <br/><br/>
-              <li>Event Details:</li>
-              <br/><br/>
-              <li>Date: Wednesday, 28th August 2024</li>
-              <br/><br/>
-              <li>Time: 11:00 am - 2:00 pm</li>
-              <br/><br/>
-              <li>Mode of Delivery: Hybrid</li>
-              <br/><br/>
-              <li>Venue 1: DSN AI Hub, Yaba, Lagos | ZOOM & YouTube</li>
-              <br/><br/>
-              <li>Venue 2: God’s Pride College, Ali Ishiba, Sango Ota, Ogun State | ZOOM & YouTube</li>
-              <br/><br/>
-              <li>This event is designed to inspire and engage young minds, introducing them to the basics of Coding and Artificial Intelligence through hands-on activities and interactive sessions.</li>
-              <br/><br/>
-              <li>Don’t miss out on this fantastic opportunity to unlock your child's hidden potential with the power of AI! Give them the opportunity to explore the exciting world of Artificial Intelligence, discover a new passion, and potentially pave the way for a future career in this dynamic field.</li>
-              <br/><br/>
-              <li>Click here to book a seat for your child: <a href="https://bit.ly/DSNAICareerDay24">https://bit.ly/DSNAICareerDay24</a></li>
-              <br/><br/>
-              <li>We look forward to seeing your child embark on this exciting journey into the world of AI.</li>
-              <br/><br/>
-              <li>God’s Pride Schools care.</li>
-            </ul>
-            <p>Don't miss out on this fantastic opportunity to make your summer unforgettable! Join us at God's
-              Pride Group of Schools and discover a world of learning, fun, and personal growth.</p>
-          </div>
-        </div>
-        <div class="announcement-card">
-          <img src="announcement-image3.jpeg" alt="Announcement 3">
-          <h3>WAEC RESULT</h3>
-          <div class="scrolling-text">
-            <p><strong>Hallelujah to Jesus! God has done it again! WAEC releases 2024 results.</strong></p>
-          </div>
-          <a href="#" class="read-more-link">Read More</a>
-          <div class="expanded-content">
-            <p>
-              We are filled with immense gratitude and joy as we celebrate the successful release of our students' WAEC results. This remarkable achievement is a testament to the dedication, hard work, and perseverance of our students, coupled with the unwavering support and prayers of each one of you.
-              We give all glory and honour to God for guiding our students through this critical phase of their academic journey. His grace has been evident in their accomplishments, and we are truly blessed to witness this wonderful success.
-              We celebrate all our dedicated and hardworking staff who worked tirelessly and took the time to nurture these champions for excellence through the help of God.
-              Thank you for your continued trust in our school and for the crucial role you played in nurturing and supporting your children. Together, we have achieved this great success, and we look forward to even greater heights in the future.
-              May God continue to bless our students as they move forward, and may His hand continue to guide them in all their endeavours. They have been empowered to soar, no going back!
-              God’s Pride Schools care.
-            </p>
-          </div>
-        </div>
+      <div class="announcement-cards" data-content="announcements">
+        <div class="loading-message" data-role="loading" hidden>Loading announcements...</div>
+        <div class="error-message" data-role="error" hidden></div>
       </div>
     </section>
 
     <section class="testimonial">
       <h2 class="section-title">What Our Students and Parents Say</h2>
-      <div class="testimonial-carousel">
-        <div class="testimonial-card">
-          <div class="testimonial-content">
-            <p>"God's Pride College Ota, will nurture your child to greatness. I am a proud parent of the school. The three students I took to the school did their JAMB & WAEC once. They came out with outstanding results."</p>
-            <cite>- Mrs. Akinsanya, Parent</cite>
-          </div>
-        </div>
-    
-        <div class="testimonial-card">
-          <div class="testimonial-content">
-            <p>"I am Mr. Abiodun, the parent of Mr. David Abiodun, a new intake student in the third term session at God's Pride School. I would like to express my heartfelt appreciation for the exceptional care and affection shown toward my son. Since enrolling, we've witnessed remarkable improvements in his growth. He successfully passed his common entrance examination. God's Pride School has truly impacted our family."</p>
-            <cite>- Mr. Abiodun, Parent</cite>
-          </div>
-        </div>
-    
-        <div class="testimonial-card">
-          <div class="testimonial-content">
-            <p>"My overall experience with God's Pride School has been very positive. The teachers are caring and dedicated. Our children's curiosity for education speaks volumes about the school. Keep up the great work!"</p>
-            <cite>- Mrs. Fabunmi, Parent</cite>
-          </div>
-        </div>
-    
-        <div class="testimonial-card">
-          <div class="testimonial-content">
-            <p>"As a parent, there are no words to fully thank the management, teachers, and staff for what they’ve done for my children. Their love, care, and academic excellence have impacted my daughters greatly. Keep up the excellent work!"</p>
-            <cite>- Mrs. Salawu, Parent</cite>
-          </div>
-        </div>
-    
-        <div class="testimonial-card">
-          <div class="testimonial-content">
-            <p>"Choosing God's Pride Schools has been one of our best decisions. Our child thrives academically and emotionally, thanks to dedicated teachers like Mrs. James, Mrs. Fadeni, and Mrs. Ikumapayi. Special thanks to Mr. Ajibade for nurturing confidence through his encouragement and praise."</p>
-            <cite>- Mrs. Daniyan, Parent</cite>
-          </div>
-        </div>
-    
-        <div class="testimonial-card">
-          <div class="testimonial-content">
-            <p>"My son, Temilade Saka, joined God’s Pride College in SS1. The reception, commitment, and moral excellence of the staff made it clear we made the right choice. From flexible support to consistent academic integrity and respect at PTA meetings, the school exceeds expectations. I proudly recommend God's Pride College to all parents seeking excellence rooted in Godly values."</p>
-            <cite>- Mr. Gbadura Saka HND, MBA, MNIM, FCTI, FCA, Parent</cite>
-          </div>
-        </div>
+      <div class="testimonial-carousel" data-content="testimonials">
+        <div class="loading-message" data-role="loading" hidden>Loading testimonials...</div>
+        <div class="error-message" data-role="error" hidden></div>
       </div>
     </section>
 
@@ -280,32 +138,9 @@
 
     <section class="media1">
       <h2 class="section-title">Media Gallery</h2>
-      <div class="media-gallery">
-        <div class="media-item">
-          <a href="gallery.html"><img src="image80.JPG" alt="Media 1"></a>
-          <div class="media-info">
-            <h3>Robotics</h3>
-          </div>
-        </div>
-        <div class="media-item">
-          <a href="gallery.html"><img src="media-image2.JPG" alt="Media 2"></a>
-          <div class="media-info">
-            <h3>Facilities</h3>
-          </div>
-        </div>
-        <div class="media-item">
-          <a href="gallery.html"><img src="media-image3.JPG" alt="Media 3"></a>
-          <div class="media-info">
-            <h3>Music</h3>
-          </div>
-        </div>
-        <div class="media-item">
-          <a href="gallery.html"><img src="media-image4.JPG" alt="Media 4"></a>
-          <div class="media-info">
-            <h3>Entrepreneurship Centre</h3>
-          </div>
-        </div>
-        <!-- Add more media items as needed -->
+      <div class="media-gallery" data-content="media-gallery">
+        <div class="loading-message" data-role="loading" hidden>Loading gallery...</div>
+        <div class="error-message" data-role="error" hidden></div>
       </div>
     </section>
 
@@ -380,6 +215,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
 </body>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gods-pride-schools-website",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static marketing site enhanced with Firebase-powered dynamic content.",
+  "scripts": {
+    "start": "npx live-server --port=4173 --entry-file=index.html"
+  },
+  "dependencies": {
+    "firebase": "^10.13.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,22 +1,3 @@
-// Handle form submission
-document.getElementById("contact-form")?.addEventListener("submit", function(event) {
-    event.preventDefault();
-  
-    // Fetch form data
-    const name = document.getElementById("name").value;
-    const email = document.getElementById("email").value;
-    const message = document.getElementById("message").value;
-  
-    // Log form data
-    console.log("Name:", name);
-    console.log("Email:", email);
-    console.log("Message:", message);
-  
-    // Optionally, display a success message or reset the form
-    alert("Form submitted successfully!");
-    this.reset(); // Reset form directly using 'this'
-});
-
 // Handle navigation toggle for mobile view
 document.addEventListener('DOMContentLoaded', function () {
     const navToggle = document.querySelector('.nav-toggle');
@@ -27,12 +8,7 @@ document.addEventListener('DOMContentLoaded', function () {
             navMenu.classList.toggle('active');
         });
     }
-});
 
-// Animate testimonials when they come into view
-document.addEventListener('DOMContentLoaded', function () {
-    const testimonialCards = document.querySelectorAll('.testimonial-card');
-    
     function isInViewport(element) {
         const rect = element.getBoundingClientRect();
         return (
@@ -40,56 +16,28 @@ document.addEventListener('DOMContentLoaded', function () {
             rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
         );
     }
-  
+
     function animateTestimonials() {
-        testimonialCards.forEach(card => {
+        document.querySelectorAll('.testimonial-card').forEach(card => {
             if (isInViewport(card)) {
                 card.classList.add('show');
             }
         });
     }
-  
-    window.addEventListener('scroll', animateTestimonials);
-    animateTestimonials(); // Run on page load
-});
 
-// Animate announcement cards when they come into view and handle "Read More" functionality
-document.addEventListener('DOMContentLoaded', function () {
-    const announcementCards = document.querySelectorAll('.announcement-card');
-    const readMoreLinks = document.querySelectorAll('.read-more-link');
-  
-    function isInViewport(element) {
-        const rect = element.getBoundingClientRect();
-        return (
-            rect.top >= 0 &&
-            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
-        );
-    }
-  
     function animateAnnouncementCards() {
-        announcementCards.forEach(card => {
+        document.querySelectorAll('.announcement-card').forEach(card => {
             if (isInViewport(card)) {
                 card.classList.add('show');
             }
         });
     }
-  
-    window.addEventListener('scroll', animateAnnouncementCards);
-    animateAnnouncementCards(); // Run on page load
-  
-    // Handle "Read More" functionality
-    readMoreLinks.forEach(link => {
-        link.addEventListener('click', function (event) {
-            event.preventDefault();
-            const card = this.closest('.announcement-card');
-            const expandedContent = card.querySelector('.expanded-content');
 
-            if (expandedContent) {
-                expandedContent.classList.toggle('show');
-                this.textContent = expandedContent.classList.contains('show') ? 'Read Less' : 'Read More';
-            }
-        });
-    });
+    window.addEventListener('scroll', animateTestimonials);
+    window.addEventListener('scroll', animateAnnouncementCards);
+
+    animateTestimonials();
+    animateAnnouncementCards();
 });
 
 // Initialize Bootstrap carousel

--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -1,0 +1,29 @@
+// Firebase initialization for the God's Pride Schools website.
+// The configuration object is provided by the bundled `firebase-config.js`
+// script, which assigns the credentials to `window.__FIREBASE_CONFIG__`.
+
+import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-app.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { getStorage } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-storage.js";
+
+const injectedConfig = window.__FIREBASE_CONFIG__;
+
+let firebaseApp = null;
+let auth = null;
+let firestore = null;
+let storage = null;
+
+if (injectedConfig && injectedConfig.apiKey) {
+  firebaseApp = getApps().length ? getApps()[0] : initializeApp(injectedConfig);
+  auth = getAuth(firebaseApp);
+  firestore = getFirestore(firebaseApp);
+  storage = getStorage(firebaseApp);
+} else {
+  console.warn(
+    "Firebase configuration not found. Define window.__FIREBASE_CONFIG__ in firebase-config.js."
+  );
+}
+
+export { firebaseApp, auth, firestore, storage };
+export const hasFirebaseConfig = Boolean(firebaseApp);

--- a/src/firebase/contentService.js
+++ b/src/firebase/contentService.js
@@ -1,0 +1,82 @@
+import { firestore, storage } from "./config.js";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  orderBy,
+  query,
+} from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";
+import { getDownloadURL, ref } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-storage.js";
+
+function assertFirestore() {
+  if (!firestore) {
+    throw new Error(
+      "Firestore is not initialized. Ensure firebase-config.js defines window.__FIREBASE_CONFIG__."
+    );
+  }
+}
+
+function assertStorage() {
+  if (!storage) {
+    throw new Error(
+      "Firebase Storage is not initialized. Ensure firebase-config.js defines window.__FIREBASE_CONFIG__."
+    );
+  }
+}
+
+function buildDocRef(path) {
+  if (!path) {
+    throw new Error("A valid document path is required.");
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length < 2 || segments.length % 2 !== 0) {
+    throw new Error(`Invalid document path: ${path}`);
+  }
+
+  assertFirestore();
+  return doc(firestore, ...segments);
+}
+
+function buildCollectionRef(path) {
+  if (!path) {
+    throw new Error("A valid collection path is required.");
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  assertFirestore();
+  return collection(firestore, ...segments);
+}
+
+export async function fetchDocument(path) {
+  const docRef = buildDocRef(path);
+  const snapshot = await getDoc(docRef);
+  if (!snapshot.exists()) {
+    throw new Error(`Document not found at path: ${path}`);
+  }
+
+  return { id: snapshot.id, ...snapshot.data() };
+}
+
+export async function fetchCollection(path, options = {}) {
+  const { orderByField, orderDirection = "asc" } = options;
+  let colRef = buildCollectionRef(path);
+
+  if (orderByField) {
+    colRef = query(colRef, orderBy(orderByField, orderDirection));
+  }
+
+  const snapshot = await getDocs(colRef);
+  return snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+export async function resolveImage(storagePath) {
+  if (!storagePath) {
+    throw new Error("A storage path is required to resolve an image.");
+  }
+
+  assertStorage();
+  const imageRef = ref(storage, storagePath);
+  return getDownloadURL(imageRef);
+}

--- a/src/firebase/fallbackData.js
+++ b/src/firebase/fallbackData.js
@@ -1,0 +1,107 @@
+export const heroFallback = {
+  title: "GOD'S PRIDE GROUP OF SCHOOLS",
+  subtitle: "God's Pride Group of Schools",
+  slogan: "Building Spiritual, Moral and Academic Excellence on a Firm Foundation",
+  tagline: "The Home Of Godly Global Champions",
+  leftLogoUrl: "logo_left.JPG",
+  rightLogoUrl: "logo_right.JPG",
+};
+
+export const carouselFallback = [
+  { imageUrl: "carousel-image4.png", title: "", caption: "" },
+  { imageUrl: "carousel-image1.jpg", title: "", caption: "" },
+  { imageUrl: "carousel-image2.jpg", title: "", caption: "" },
+  { imageUrl: "carousel-image3.jpg", title: "", caption: "" },
+];
+
+export const announcementsFallback = [
+  {
+    title: "ADMISSIONS NOW OPEN!!!",
+    summary: "Admissions Are Open for God's Pride School!",
+    imageUrl: "announcement-image1.jpeg",
+    ctaLabel: "Read More",
+    ctaLink: "#",
+    content:
+      "<p>Admissions Are Open at God's Pride School! Explore an educational journey grounded in faith, excellence, and innovation at God's Pride School. As a mandate and a God-given institution, we are driven by a powerful vision and mission: to raise a generation of new academics firmly founded on Godly values.</p>",
+  },
+  {
+    title: "2024 Summer Splash !!!",
+    summary: "🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞",
+    imageUrl: "announcement-image2.jpeg",
+    ctaLabel: "Read More",
+    ctaLink: "#",
+    content:
+      "<p><strong>🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞</strong></p>" +
+      "<p>Empowering Kids and Teens to Explore the World of Coding and Artificial Intelligence Through Hands-on Activities and Interactive Sessions organized by DSN.</p>" +
+      "<p><strong>Highlights:</strong></p>" +
+      "<ul>" +
+      "<li>Dear Parent,</li>" +
+      "<li>We are thrilled to invite your child to the FREE AI Career Development Event for Kids and Teens.</li>" +
+      "<li>Event Details:</li>" +
+      "<li>Date: Wednesday, 28th August 2024</li>" +
+      "<li>Time: 11:00 am - 2:00 pm</li>" +
+      "<li>Mode of Delivery: Hybrid</li>" +
+      "<li>Venue 1: DSN AI Hub, Yaba, Lagos | ZOOM &amp; YouTube</li>" +
+      "<li>Venue 2: God’s Pride College, Ali Ishiba, Sango Ota, Ogun State | ZOOM &amp; YouTube</li>" +
+      "<li>This event is designed to inspire and engage young minds, introducing them to the basics of Coding and Artificial Intelligence through hands-on activities and interactive sessions.</li>" +
+      "<li>Don’t miss out on this fantastic opportunity to unlock your child's hidden potential with the power of AI! Give them the opportunity to explore the exciting world of Artificial Intelligence, discover a new passion, and potentially pave the way for a future career in this dynamic field.</li>" +
+      "<li>Click here to book a seat for your child: <a href=\"https://bit.ly/DSNAICareerDay24\">https://bit.ly/DSNAICareerDay24</a></li>" +
+      "<li>We look forward to seeing your child embark on this exciting journey into the world of AI.</li>" +
+      "<li>God’s Pride Schools care.</li>" +
+      "</ul>" +
+      "<p>Don't miss out on this fantastic opportunity to make your summer unforgettable! Join us at God's Pride Group of Schools and discover a world of learning, fun, and personal growth.</p>",
+  },
+  {
+    title: "WAEC RESULT",
+    summary: "Hallelujah to Jesus! God has done it again! WAEC releases 2024 results.",
+    imageUrl: "announcement-image3.jpeg",
+    ctaLabel: "Read More",
+    ctaLink: "#",
+    content:
+      "<p>We are filled with immense gratitude and joy as we celebrate the successful release of our students' WAEC results. This remarkable achievement is a testament to the dedication, hard work, and perseverance of our students, coupled with the unwavering support and prayers of each one of you.</p>" +
+      "<p>We give all glory and honour to God for guiding our students through this critical phase of their academic journey. His grace has been evident in their accomplishments, and we are truly blessed to witness this wonderful success.</p>" +
+      "<p>We celebrate all our dedicated and hardworking staff who worked tirelessly and took the time to nurture these champions for excellence through the help of God.</p>" +
+      "<p>Thank you for your continued trust in our school and for the crucial role you played in nurturing and supporting your children. Together, we have achieved this great success, and we look forward to even greater heights in the future.</p>" +
+      "<p>May God continue to bless our students as they move forward, and may His hand continue to guide them in all their endeavours. They have been empowered to soar, no going back! God’s Pride Schools care.</p>",
+  },
+];
+
+export const testimonialsFallback = [
+  {
+    quote:
+      "God's Pride College Ota, will nurture your child to greatness. I am a proud parent of the school. The three students I took to the school did their JAMB & WAEC once. They came out with outstanding results.",
+    author: "- Mrs. Akinsanya, Parent",
+  },
+  {
+    quote:
+      "I am Mr. Abiodun, the parent of Mr. David Abiodun, a new intake student in the third term session at God's Pride School. I would like to express my heartfelt appreciation for the exceptional care and affection shown toward my son. Since enrolling, we've witnessed remarkable improvements in his growth. He successfully passed his common entrance examination. God's Pride School has truly impacted our family.",
+    author: "- Mr. Abiodun, Parent",
+  },
+  {
+    quote:
+      "My overall experience with God's Pride School has been very positive. The teachers are caring and dedicated. Our children's curiosity for education speaks volumes about the school. Keep up the great work!",
+    author: "- Mrs. Fabunmi, Parent",
+  },
+  {
+    quote:
+      "As a parent, there are no words to fully thank the management, teachers, and staff for what they’ve done for my children. Their love, care, and academic excellence have impacted my daughters greatly. Keep up the excellent work!",
+    author: "- Mrs. Salawu, Parent",
+  },
+  {
+    quote:
+      "Choosing God's Pride Schools has been one of our best decisions. Our child thrives academically and emotionally, thanks to dedicated teachers like Mrs. James, Mrs. Fadeni, and Mrs. Ikumapayi. Special thanks to Mr. Ajibade for nurturing confidence through his encouragement and praise.",
+    author: "- Mrs. Daniyan, Parent",
+  },
+  {
+    quote:
+      "My son, Temilade Saka, joined God’s Pride College in SS1. The reception, commitment, and moral excellence of the staff made it clear we made the right choice. From flexible support to consistent academic integrity and respect at PTA meetings, the school exceeds expectations. I proudly recommend God's Pride College to all parents seeking excellence rooted in Godly values.",
+    author: "- Mr. Gbadura Saka HND, MBA, MNIM, FCTI, FCA, Parent",
+  },
+];
+
+export const mediaFallback = [
+  { title: "Robotics", imageUrl: "image80.JPG", link: "gallery.html" },
+  { title: "Facilities", imageUrl: "media-image2.JPG", link: "gallery.html" },
+  { title: "Music", imageUrl: "media-image3.JPG", link: "gallery.html" },
+  { title: "Entrepreneurship Centre", imageUrl: "media-image4.JPG", link: "gallery.html" },
+];

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,545 @@
+import {
+  fetchCollection,
+  fetchDocument,
+  resolveImage,
+} from "./firebase/contentService.js";
+import {
+  announcementsFallback,
+  carouselFallback,
+  heroFallback,
+  mediaFallback,
+  testimonialsFallback,
+} from "./firebase/fallbackData.js";
+
+const CAROUSEL_COLLECTION = "siteContent/carouselSlides";
+const ANNOUNCEMENTS_COLLECTION = "siteContent/announcements";
+const TESTIMONIALS_COLLECTION = "siteContent/testimonials";
+const MEDIA_COLLECTION = "siteContent/mediaGallery";
+const HERO_DOCUMENT = "siteContent/homeHero";
+
+const loadingClass = "content-loading";
+const errorClass = "content-error";
+const TRANSPARENT_PIXEL = "data:image/gif;base64,R0lGODlhAQABAAAAACw=";
+
+function toggleState(element, { loading = false, message = "" } = {}) {
+  if (!element) return;
+
+  element.textContent = message;
+  element.hidden = !loading && !message;
+  element.classList.toggle(loadingClass, loading);
+  element.classList.toggle(errorClass, !loading && Boolean(message));
+}
+
+function setImageSource(image, { imageUrl, storagePath }) {
+  if (!image) return;
+
+  if (imageUrl) {
+    image.src = imageUrl;
+    image.dataset.loaded = "true";
+    return;
+  }
+
+  if (storagePath) {
+    image.dataset.storagePath = storagePath;
+    image.src = TRANSPARENT_PIXEL;
+  }
+}
+
+async function renderHeroSection() {
+  const heroTitle = document.querySelector("[data-firestore-field='hero-title']");
+  const heroSubtitle = document.querySelector("[data-firestore-field='hero-subtitle']");
+  const heroSlogan = document.querySelector("[data-firestore-field='hero-slogan']");
+  const heroTagline = document.querySelector("[data-firestore-field='hero-tagline']");
+  const leftLogo = document.querySelector("[data-storage-field='leftLogoPath']");
+  const rightLogo = document.querySelector("[data-storage-field='rightLogoPath']");
+  const loading = document.querySelector("#hero-loading");
+  const error = document.querySelector("#hero-error");
+
+  [leftLogo, rightLogo].forEach((image) => {
+    if (image && !image.src && image.dataset.placeholder) {
+      image.src = image.dataset.placeholder;
+    }
+  });
+
+  toggleState(loading, { loading: true, message: "Loading school profile..." });
+  toggleState(error);
+
+  let heroDoc = null;
+
+  try {
+    heroDoc = await fetchDocument(HERO_DOCUMENT);
+  } catch (heroError) {
+    console.error("Failed to fetch hero document:", heroError);
+  }
+
+  const heroData = { ...heroFallback, ...(heroDoc || {}) };
+
+  if (heroTitle) {
+    heroTitle.textContent = heroData.title;
+  }
+  if (heroSubtitle) {
+    heroSubtitle.textContent = heroData.subtitle;
+  }
+  if (heroSlogan) {
+    heroSlogan.textContent = heroData.slogan;
+  }
+  if (heroTagline) {
+    heroTagline.textContent = heroData.tagline;
+  }
+
+  const logos = [
+    { element: leftLogo, storagePath: heroData.leftLogoPath, imageUrl: heroData.leftLogoUrl },
+    { element: rightLogo, storagePath: heroData.rightLogoPath, imageUrl: heroData.rightLogoUrl },
+  ];
+
+  await Promise.all(
+    logos.map(async ({ element, storagePath, imageUrl }) => {
+      if (!element) {
+        return;
+      }
+
+      if (imageUrl) {
+        element.src = imageUrl;
+        element.dataset.loaded = "true";
+        return;
+      }
+
+      if (!storagePath) {
+        return;
+      }
+
+      try {
+        const url = await resolveImage(storagePath);
+        element.src = url;
+        element.dataset.loaded = "true";
+      } catch (logoError) {
+        console.error(`Failed to load storage asset for ${storagePath}:`, logoError);
+        element.alt = "Image unavailable";
+      }
+    })
+  );
+
+  toggleState(loading);
+}
+
+function createAnnouncementCard({ title, summary, content, imagePath, imageUrl, ctaLabel, ctaLink }) {
+  const card = document.createElement("div");
+  card.className = "announcement-card";
+
+  const image = document.createElement("img");
+  image.alt = title || "Announcement";
+  setImageSource(image, { imageUrl, storagePath: imagePath });
+  if (!image.dataset.loaded) {
+    if (!image.src) {
+      image.src = TRANSPARENT_PIXEL;
+    }
+  }
+  card.appendChild(image);
+
+  if (title) {
+    const heading = document.createElement("h3");
+    heading.textContent = title;
+    card.appendChild(heading);
+  }
+
+  if (summary) {
+    const summaryContainer = document.createElement("div");
+    summaryContainer.className = "scrolling-text";
+    summaryContainer.innerHTML = `<p><strong>${summary}</strong></p>`;
+    card.appendChild(summaryContainer);
+  }
+
+  const hasContent = Boolean(content);
+  const effectiveCtaLabel = ctaLabel || (hasContent ? "Read More" : "");
+
+  if (effectiveCtaLabel) {
+    const link = document.createElement("a");
+    link.className = "read-more-link";
+    link.href = ctaLink || "#";
+    link.textContent = effectiveCtaLabel;
+    card.appendChild(link);
+  }
+
+  if (hasContent) {
+    const expanded = document.createElement("div");
+    expanded.className = "expanded-content";
+    expanded.innerHTML = content;
+    card.appendChild(expanded);
+  }
+
+  return card;
+}
+
+async function renderAnnouncements() {
+  const container = document.querySelector("[data-content='announcements']");
+  const loading = container?.querySelector("[data-role='loading']");
+  const error = container?.querySelector("[data-role='error']");
+
+  toggleState(loading, { loading: true, message: "Loading announcements..." });
+  toggleState(error);
+
+  container?.querySelectorAll(".announcement-card").forEach((card) => card.remove());
+
+  let announcements = [];
+  let usedFallback = false;
+
+  try {
+    announcements = await fetchCollection(ANNOUNCEMENTS_COLLECTION, {
+      orderByField: "priority",
+      orderDirection: "desc",
+    });
+  } catch (announcementError) {
+    console.error("Failed to fetch announcements:", announcementError);
+    announcements = announcementsFallback;
+    usedFallback = true;
+  }
+
+  if (!announcements.length) {
+    const message = usedFallback
+      ? "Announcements are temporarily unavailable."
+      : "No announcements available yet. Please check back soon.";
+    toggleState(error, { message });
+    toggleState(loading);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  for (const announcement of announcements) {
+    fragment.appendChild(createAnnouncementCard(announcement));
+  }
+
+  container?.appendChild(fragment);
+
+  const images = container?.querySelectorAll("img[data-storage-path]") ?? [];
+  await loadStorageImages(images);
+
+  toggleState(loading);
+}
+
+function createCarouselItem({ title, caption, imagePath, imageUrl }, index) {
+  const item = document.createElement("div");
+  item.className = "carousel-item";
+  if (index === 0) {
+    item.classList.add("active");
+  }
+
+  const image = document.createElement("img");
+  image.className = "d-block w-100";
+  image.alt = title || `Slide ${index + 1}`;
+  setImageSource(image, { imageUrl, storagePath: imagePath });
+  if (!image.dataset.loaded) {
+    if (!image.src) {
+      image.src = TRANSPARENT_PIXEL;
+    }
+  }
+  item.appendChild(image);
+
+  if (title || caption) {
+    const captionContainer = document.createElement("div");
+    captionContainer.className = "carousel-caption d-none d-md-block";
+    if (title) {
+      const heading = document.createElement("h5");
+      heading.textContent = title;
+      captionContainer.appendChild(heading);
+    }
+    if (caption) {
+      const paragraph = document.createElement("p");
+      paragraph.textContent = caption;
+      captionContainer.appendChild(paragraph);
+    }
+    item.appendChild(captionContainer);
+  }
+
+  return item;
+}
+
+async function renderCarousel() {
+  const indicators = document.querySelector("#myCarousel .carousel-indicators");
+  const inner = document.querySelector("#myCarousel .carousel-inner");
+  const loading = document.querySelector("#carousel-loading");
+  const error = document.querySelector("#carousel-error");
+
+  toggleState(loading, { loading: true, message: "Loading highlights..." });
+  toggleState(error);
+
+  let slides = [];
+  let usedFallback = false;
+
+  try {
+    slides = await fetchCollection(CAROUSEL_COLLECTION, {
+      orderByField: "order",
+      orderDirection: "asc",
+    });
+  } catch (carouselError) {
+    console.error("Failed to fetch carousel slides:", carouselError);
+    slides = carouselFallback;
+    usedFallback = true;
+  }
+
+  if (!slides.length) {
+    const message = usedFallback ? "Highlights are temporarily unavailable." : "No highlights available yet.";
+    toggleState(error, { message });
+    toggleState(loading);
+    return;
+  }
+
+  indicators.innerHTML = "";
+  inner.innerHTML = "";
+
+  const indicatorFragment = document.createDocumentFragment();
+  const slideFragment = document.createDocumentFragment();
+
+  slides.forEach((slide, index) => {
+    const indicator = document.createElement("li");
+    indicator.dataset.target = "#myCarousel";
+    indicator.dataset.slideTo = index;
+    if (index === 0) {
+      indicator.classList.add("active");
+    }
+    indicatorFragment.appendChild(indicator);
+
+    const item = createCarouselItem(slide, index);
+    slideFragment.appendChild(item);
+  });
+
+  indicators.appendChild(indicatorFragment);
+  inner.appendChild(slideFragment);
+
+  const images = inner.querySelectorAll("img[data-storage-path]");
+  await loadStorageImages(images);
+
+  if (window.jQuery && window.jQuery.fn && window.jQuery.fn.carousel) {
+    window.jQuery("#myCarousel").carousel({ interval: 5000, pause: "hover", wrap: true });
+  }
+
+  toggleState(loading);
+}
+
+function createTestimonialCard({ quote, author }) {
+  const card = document.createElement("div");
+  card.className = "testimonial-card";
+
+  const content = document.createElement("div");
+  content.className = "testimonial-content";
+
+  if (quote) {
+    const paragraph = document.createElement("p");
+    paragraph.textContent = quote;
+    content.appendChild(paragraph);
+  }
+
+  if (author) {
+    const cite = document.createElement("cite");
+    cite.textContent = author;
+    content.appendChild(cite);
+  }
+
+  card.appendChild(content);
+  return card;
+}
+
+function initTestimonialCarousel(container) {
+  if (!(window.jQuery && window.jQuery.fn && window.jQuery.fn.slick)) {
+    return;
+  }
+
+  const $container = window.jQuery(container);
+  if ($container.hasClass("slick-initialized")) {
+    $container.slick("unslick");
+  }
+
+  $container.slick({
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 2,
+    slidesToScroll: 1,
+    responsive: [
+      {
+        breakpoint: 768,
+        settings: {
+          slidesToShow: 1,
+        },
+      },
+    ],
+  });
+}
+
+async function renderTestimonials() {
+  const container = document.querySelector("[data-content='testimonials']");
+  const loading = container?.querySelector("[data-role='loading']");
+  const error = container?.querySelector("[data-role='error']");
+
+  toggleState(loading, { loading: true, message: "Loading testimonials..." });
+  toggleState(error);
+
+  container?.querySelectorAll(".testimonial-card").forEach((card) => card.remove());
+
+  let testimonials = [];
+  let usedFallback = false;
+
+  try {
+    testimonials = await fetchCollection(TESTIMONIALS_COLLECTION, {
+      orderByField: "order",
+    });
+  } catch (testimonialError) {
+    console.error("Failed to fetch testimonials:", testimonialError);
+    testimonials = testimonialsFallback;
+    usedFallback = true;
+  }
+
+  if (!testimonials.length) {
+    const message = usedFallback
+      ? "Testimonials are temporarily unavailable."
+      : "Testimonials will be available soon.";
+    toggleState(error, { message });
+    toggleState(loading);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  testimonials.forEach((testimonial) => {
+    fragment.appendChild(createTestimonialCard(testimonial));
+  });
+
+  container?.appendChild(fragment);
+  initTestimonialCarousel(container);
+
+  toggleState(loading);
+}
+
+function createMediaCard({ title, imagePath, imageUrl, link }) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "media-item";
+
+  const anchor = document.createElement("a");
+  anchor.href = link || "#";
+
+  const image = document.createElement("img");
+  image.alt = title || "Media";
+  setImageSource(image, { imageUrl, storagePath: imagePath });
+  if (!image.dataset.loaded) {
+    if (!image.src) {
+      image.src = TRANSPARENT_PIXEL;
+    }
+  }
+
+  anchor.appendChild(image);
+  wrapper.appendChild(anchor);
+
+  if (title) {
+    const info = document.createElement("div");
+    info.className = "media-info";
+    const heading = document.createElement("h3");
+    heading.textContent = title;
+    info.appendChild(heading);
+    wrapper.appendChild(info);
+  }
+
+  return wrapper;
+}
+
+async function renderMediaGallery() {
+  const container = document.querySelector("[data-content='media-gallery']");
+  const loading = container?.querySelector("[data-role='loading']");
+  const error = container?.querySelector("[data-role='error']");
+
+  toggleState(loading, { loading: true, message: "Loading gallery..." });
+  toggleState(error);
+
+  container?.querySelectorAll(".media-item").forEach((item) => item.remove());
+
+  let mediaItems = [];
+  let usedFallback = false;
+
+  try {
+    mediaItems = await fetchCollection(MEDIA_COLLECTION, {
+      orderByField: "order",
+    });
+  } catch (mediaError) {
+    console.error("Failed to fetch media gallery:", mediaError);
+    mediaItems = mediaFallback;
+    usedFallback = true;
+  }
+
+  if (!mediaItems.length) {
+    const message = usedFallback
+      ? "Media gallery is temporarily unavailable."
+      : "Gallery will be updated soon.";
+    toggleState(error, { message });
+    toggleState(loading);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  mediaItems.forEach((item) => fragment.appendChild(createMediaCard(item)));
+  container?.appendChild(fragment);
+
+  const images = container?.querySelectorAll("img[data-storage-path]") ?? [];
+  await loadStorageImages(images);
+
+  toggleState(loading);
+}
+
+async function loadStorageImages(images) {
+  await Promise.all(
+    Array.from(images).map(async (image) => {
+      if (image.dataset.loaded === "true") {
+        return;
+      }
+
+      const storagePath = image.dataset.storagePath || image.dataset.storageField;
+      if (!storagePath) {
+        return;
+      }
+
+      try {
+        const url = await resolveImage(storagePath);
+        image.src = url;
+        image.dataset.loaded = "true";
+      } catch (storageError) {
+        console.error(`Failed to load image at ${storagePath}`, storageError);
+        image.alt = "Image unavailable";
+      }
+    })
+  );
+}
+
+function hydrateReadMoreLinks(container) {
+  container.querySelectorAll(".read-more-link").forEach((link) => {
+    link.addEventListener("click", (event) => {
+      event.preventDefault();
+      const card = link.closest(".announcement-card");
+      const expandedContent = card?.querySelector(".expanded-content");
+
+      if (expandedContent) {
+        expandedContent.classList.toggle("show");
+        link.textContent = expandedContent.classList.contains("show")
+          ? "Read Less"
+          : "Read More";
+      }
+    });
+  });
+}
+
+async function bootstrapDynamicContent() {
+  await Promise.all([
+    renderHeroSection(),
+    renderCarousel(),
+    renderAnnouncements(),
+    renderTestimonials(),
+    renderMediaGallery(),
+  ]);
+
+  const announcementsContainer = document.querySelector("[data-content='announcements']");
+  if (announcementsContainer) {
+    hydrateReadMoreLinks(announcementsContainer);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  bootstrapDynamicContent().catch((error) => {
+    console.error("Failed to bootstrap dynamic content", error);
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,26 @@ body {
   display: block;
 }
 
+.loading-message,
+.error-message {
+  margin: 10px 0;
+  padding: 10px 15px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.content-loading,
+.loading-message {
+  background-color: rgba(0, 128, 0, 0.08);
+  color: #0b4f0b;
+}
+
+.content-error,
+.error-message {
+  background-color: rgba(220, 53, 69, 0.1);
+  color: #842029;
+}
+
 /* Container */
 .container {
   max-width: 1200px;
@@ -52,6 +72,17 @@ header {
 
 .logo img {
   max-height: 50px;
+}
+
+.logo img:not([data-loaded="true"]) {
+  background-color: #f0f0f0;
+  border-radius: 4px;
+}
+
+.hero-copy {
+  flex: 1 1 300px;
+  text-align: center;
+  padding: 0 20px;
 }
 
 header h1 {


### PR DESCRIPTION
## Summary
- ship the production Firebase credentials in the committed firebase-config.js script so the app boots with the real project without renaming samples
- guard Firebase initialisation and service helpers, and feed the homepage renderers with static fallback content so sections remain populated when Firestore/Storage are unavailable
- keep client-side navigation/animation hooks while restoring the contact form’s default submission behaviour

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e14e764f6c832d9b1212a918b7887d