### PR TITLE
Integrate Firestore-backed content hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+src/firebase/config.js
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# God's Pride Schools Website – Dynamic Content Guide
+
+This repository powers the static deployment of the God's Pride Group of Schools website. The UI is still served as plain HTML/CSS/JS, but key copy, carousels, testimonials, and galleries are now hydrated from Firebase Firestore so the communications team can publish updates without touching the codebase.
+
+## Runtime architecture
+
+- **Static shell** – The HTML pages remain in the repository and are deployed to GitHub Pages as before.
+- **Firebase bootstrap** – Each page loads a `firebase-config.js` file (ignored by Git) that sets `window.__FIREBASE_CONFIG__`. The helper in `src/firebase/app.js` initialises the Firebase SDK using that global config.
+- **Data hooks** – `src/hooks/useFirestore.js` exposes `useDocument`/`useCollection` helpers with in-memory caching and graceful fallbacks.
+- **Page hydration** – `src/main.js` scans for elements annotated with `data-document`/`data-field`/`data-collection` attributes, fetches the relevant Firestore records, swaps the DOM content, and dispatches events for widgets (e.g., Slick slider) to reinitialise.
+- **Fallback safety** – Before overwriting any DOM node, the script caches its original markup. If Firestore is unreachable, stale, or missing fields, the static fallback is restored.
+
+## Getting started locally
+
+1. **Install dependencies:** No npm install is required; the site uses browser ESM modules and CDN-delivered Firebase packages.
+2. **Provide Firebase credentials:**
+   - Copy `src/firebase/config.sample.js` to `firebase-config.js` in the repository root (same level as `index.html`).
+   - Replace the placeholders with your Firebase project's web config and export it globally:
+
+     ```html
+     <!-- firebase-config.js -->
+     <script>
+       window.__FIREBASE_CONFIG__ = {
+         apiKey: 'YOUR_API_KEY',
+         authDomain: 'YOUR_AUTH_DOMAIN',
+         projectId: 'YOUR_PROJECT_ID',
+         storageBucket: 'YOUR_STORAGE_BUCKET',
+         messagingSenderId: 'YOUR_SENDER_ID',
+         appId: 'YOUR_APP_ID',
+       };
+     </script>
+     ```
+
+   - The file is ignored by Git to keep secrets out of source control.
+3. **Serve the site:** Open `index.html` through any static web server (e.g., `python -m http.server`).
+4. **Verify data:** With a valid Firebase config and populated Firestore, dynamic sections (announcements, testimonials, galleries, etc.) will populate automatically. Without Firebase or network access, the static fallbacks remain visible.
+
+## Firestore content model
+
+Consult [`docs/content-audit.md`](docs/content-audit.md) for a full matrix of page components mapped to Firestore paths. The high-level structure is:
+
+- `settings/global` (document)
+  - `siteName`, `tagline`, `logos.left.url`, `logos.right.url`
+  - `contact.email`, `contact.phone`, `address`
+  - `social.facebook`, `social.instagram`
+  - `footer.copyright`
+- `settings/homepage` (document)
+  - `intro.title`, `intro.marquee`
+  - `announcements.heading`, `testimonials.heading`
+- `announcements` (collection)
+  - Fields: `title`, `summary`, `body` (HTML), `image.url`, `image.alt`, `publishedAt`, optional `priority`
+- `testimonials` (collection)
+  - Fields: `quote`, `author`, optional `publishedAt`, `priority`
+- `news` (collection)
+  - Fields: `title`, `summary`, `body`, `image.url`, `publishedAt`, `link`
+- `media/homeCarousel` & `media/gallery` (collections)
+  - Fields: `url`, `alt`, optional `caption`, `description`, `order`
+- Page-specific documents under `content/`
+  - `content/about`, `content/admissions`, `content/contact`, `content/news`, `content/gallery`
+  - `content/schools`, `content/nurseryPrimary`, `content/secondary`
+
+## Publishing workflow for administrators
+
+1. **Plan the update** – Identify the section you want to change and look up its Firestore path in [`docs/content-audit.md`](docs/content-audit.md).
+2. **Edit Firestore content** – Use the Firebase console (or an admin tool) to update the document/collection values. Rich text fields accept HTML, which will be inserted directly into the page.
+3. **Upload media** – Host images in Firebase Storage (or elsewhere) and store the public download URL in the relevant document (`media/*` collections, `image.url` fields). Include `caption`/`alt` text for accessibility.
+4. **Save and publish** – Changes go live immediately because the site reads directly from Firestore on each page load. The helper caches responses for five minutes; edits propagate across visitors after that cache window or when a user refreshes.
+5. **Fallback awareness** – If a field is missing or Firestore is unavailable, the site reverts to the original static copy committed in this repo. Keep those fallbacks reasonably up to date for resilience.
+
+### Adding new repeatable content
+
+- **Announcements/testimonials/news** – Add a document to the relevant collection. Ordering is controlled via `publishedAt` (descending) and optional `priority` numbers.
+- **Carousel images** – Add a document to `media/homeCarousel` with `url`, optional `caption`, and optional numeric `order`.
+- **Gallery images** – Add documents to `media/gallery`. Images appear in ascending `order`; if omitted they render in insertion order.
+
+### Maintenance tips
+
+- Because the project is static, no build step is required. Ensure `firebase-config.js` ships alongside the HTML on the hosting platform.
+- Keep Firestore security rules tight—limit write access to authorised admins.
+- When adding new dynamic sections, annotate the HTML with `data-document`/`data-field` or `data-collection` attributes and update the audit document so future maintainers know where the content lives.
+
+## Troubleshooting
+
+- **Nothing loads / still shows old copy:** Verify `firebase-config.js` is present and includes valid credentials. Check the browser console for Firebase errors.
+- **Images missing:** Ensure the Firestore document includes a `url` pointing to a publicly accessible image. Remember to redeploy any new static assets if you are hosting images within the repo.
+- **Carousel/testimonial slider misbehaving:** Hydration dispatches a `collection:hydrated` event after data loads. If you add new sliders, hook into that event (see `script.js`) to reinitialise any third-party widgets.
+
+With this workflow, school administrators can keep announcements, admissions information, testimonials, and visual media fresh directly from Firebase while preserving the lightweight static deployment.

--- a/Secondary_School.html
+++ b/Secondary_School.html
@@ -13,14 +13,23 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="secondary">
   <header>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
+    <div class="logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
+    </div>
   </header>
 
   <nav>
@@ -35,7 +44,7 @@
       <li><a href="contact.html">Contact</a></li>
     </ul>
   </nav>
-  <section class="image-carousel">
+  <section class="image-carousel" data-document="content/secondary" data-field="hero" data-field-type="html">
     <div id="myCarousel" class="carousel slide" data-ride="carousel">
       <ol class="carousel-indicators">
         <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
@@ -84,12 +93,13 @@
   </section>
 
   <div class="container">
-    <section class="announcement">
+    <section class="announcement" data-document="content/secondary" data-field="overview" data-field-type="html">
       <h2>GOD'S PRIDE COLLEGE</h2>
       <p>The Home Of Godly Global Champions</p>
     </section>
 
-    <section class="testimonial">
+    <section class="testimonial" data-document="content/secondary" data-field="testimonials"
+      data-field-type="html">
       <h2>What Our Students and Parent Say</h2>
       <div class="testimonial-card">
         <div class="testimonial-content">
@@ -159,7 +169,7 @@
       </div>
     </section>
 
-  <section class="contact">
+  <section class="contact" data-document="content/secondary" data-field="contact" data-field-type="html">
     <h2>Contact Us</h2>
     <div class="contact-form">
       <form action="https://formsubmit.co/8da530955ad70219843754c8964446b6" method="POST">
@@ -195,8 +205,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -213,19 +225,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -234,6 +248,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/about.html
+++ b/about.html
@@ -13,16 +13,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="about">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
     </div>
   </header>
 
@@ -40,14 +46,16 @@
 
   <main class="container">
     <section class="about">
-      <h2 class="section-title">About Us</h2>
+      <h2 class="section-title" data-document="content/about" data-field="title">About Us</h2>
       <div class="about-section owner">
         <div class="owner-image">
-          <img src="owner-image.jpg" alt="Mrs. Mojisola Sowunmi, Proprietor" class="responsive-image">
+          <img src="owner-image.jpg" alt="Mrs. Mojisola Sowunmi, Proprietor" class="responsive-image"
+            data-document="content/about" data-field="owner.image.url" data-attr="src"
+            data-fallback="owner-image.jpg">
         </div>
         <div class="owner-info">
-          <h3>The Proprietor</h3>
-          <p>
+          <h3 data-document="content/about" data-field="owner.title">The Proprietor</h3>
+          <p data-document="content/about" data-field="owner.description" data-field-type="html">
             Mrs. Sowunmi O. Mojisola, an extraordinary educator, responded to a divine calling to nurture children and
             youth. She and her husband Mr. Oludare O. Sowunmi founded God's Pride Schools and God's Pride Educational
             Consultancy. As CEO, she orchestrates collaborative efforts, elevating standards and opportunities. She
@@ -67,41 +75,43 @@
         </div>
       </div>
       <div class="about-section mandate">
-        <h3>The Mandate</h3>
-        <p>God's Pride School is a mandate and a God-given school born out of the vision and mission to raise a
-          generation of new academics founded on Godly values. That is why our Motto for the Primary School is "Firm
-          Foundation." We are called to raise a child firmly rooted and established in God. Colossians 2:7.</p>
+        <h3 data-document="content/about" data-field="mandate.title">The Mandate</h3>
+        <p data-document="content/about" data-field="mandate.description" data-field-type="html">God's Pride School is
+          a mandate and a God-given school born out of the vision and mission to raise a generation of new academics
+          founded on Godly values. That is why our Motto for the Primary School is "Firm Foundation." We are called to
+          raise a child firmly rooted and established in God. Colossians 2:7.</p>
       </div>
       <div class="about-section vision">
-        <h3>Our Vision</h3>
-        <p>Our vision is based on certain fundamental principles that are bound to basic moral, spiritual, and academic
-          excellence that will make every child excel in different areas of life in his or her future endeavors, thus
-          becoming a pride to his/her parent, nation, the world at large, and to God Almighty, the creator of heaven and
-          earth.</p>
+        <h3 data-document="content/about" data-field="vision.title">Our Vision</h3>
+        <p data-document="content/about" data-field="vision.description" data-field-type="html">Our vision is based on
+          certain fundamental principles that are bound to basic moral, spiritual, and academic excellence that will
+          make every child excel in different areas of life in his or her future endeavors, thus becoming a pride to
+          his/her parent, nation, the world at large, and to God Almighty, the creator of heaven and earth.</p>
       </div>
       <div class="about-section mission">
-        <h3>Our Mission</h3>
-        <p>To create a purpose-driven youth; thereby helping them identify their individual gifts, talents, and
-          potentials, thus helping them grow into educated, responsible, and reliable global citizens on whom their
-          parents, society, the nation, the world at large, and God can rely on.</p>
+        <h3 data-document="content/about" data-field="mission.title">Our Mission</h3>
+        <p data-document="content/about" data-field="mission.description" data-field-type="html">To create a
+          purpose-driven youth; thereby helping them identify their individual gifts, talents, and potentials, thus
+          helping them grow into educated, responsible, and reliable global citizens on whom their parents, society, the
+          nation, the world at large, and God can rely on.</p>
       </div>
       <div class="about-section values">
-        <h3>Our Values</h3>
-        <p>Our values are based solely on the word of God (2 Peter 1:5-7). At God's Pride School, we also teach our
-          pupils and students practical life skills, vocational and entrepreneurial skills, life skills values, good
-          etiquette and manners, Jolly phonics, and diction; how to speak right so that they will be able to stand out
-          anywhere they go. Apart from academics, we help our students to develop holistically. The students are
-          inspired and encouraged to work hard to achieve all-around excellence in life and also to develop their
-          leadership qualities.</p>
+        <h3 data-document="content/about" data-field="values.title">Our Values</h3>
+        <p data-document="content/about" data-field="values.description" data-field-type="html">Our values are based
+          solely on the word of God (2 Peter 1:5-7). At God's Pride School, we also teach our pupils and students
+          practical life skills, vocational and entrepreneurial skills, life skills values, good etiquette and manners,
+          Jolly phonics, and diction; how to speak right so that they will be able to stand out anywhere they go. Apart
+          from academics, we help our students to develop holistically. The students are inspired and encouraged to work
+          hard to achieve all-around excellence in life and also to develop their leadership qualities.</p>
       </div>
       <div class="about-section entrepreneurship">
-        <h3>God's Pride Entrepreneurship Centre</h3>
-        <p>All students, irrespective of their chosen area of discipline, must take two entrepreneurship courses, of
-          which computer education is compulsory. Other courses we will be introducing will include electrical
-          installation and maintenance, catering and hospitality management, tailoring and fashion design, hat making,
-          leather goods production, event decoration, and planning. This is to ensure every student of the college
-          acquires a minimum of two skills he/she can practice to generate income during and after graduating from the
-          college.</p>
+        <h3 data-document="content/about" data-field="entrepreneurship.title">God's Pride Entrepreneurship Centre</h3>
+        <p data-document="content/about" data-field="entrepreneurship.description" data-field-type="html">All
+          students, irrespective of their chosen area of discipline, must take two entrepreneurship courses, of which
+          computer education is compulsory. Other courses we will be introducing will include electrical installation
+          and maintenance, catering and hospitality management, tailoring and fashion design, hat making, leather goods
+          production, event decoration, and planning. This is to ensure every student of the college acquires a minimum
+          of two skills he/she can practice to generate income during and after graduating from the college.</p>
       </div>
     </section>
   </main>
@@ -111,8 +121,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -128,19 +140,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -149,6 +163,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/admission.html
+++ b/admission.html
@@ -13,16 +13,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="admission">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
     </div>
   </header>
 
@@ -40,10 +46,10 @@
   <div class="container">
     <section class="admissions">
       <div class="admission-intro">
-        <h2 class="section-title">Begin Your Child’s Journey with Us</h2>
-        <p class="section-intro">We welcome students all year, space permitting. Whether transferring or starting fresh, we guide families through a caring, efficient admissions process.</p>
-      
-        <div class="admissions-steps">
+        <h2 class="section-title" data-document="content/admissions" data-field="hero.title">Begin Your Child’s Journey with Us</h2>
+        <p class="section-intro" data-document="content/admissions" data-field="hero.intro" data-field-type="html">We welcome students all year, space permitting. Whether transferring or starting fresh, we guide families through a caring, efficient admissions process.</p>
+
+        <div class="admissions-steps" data-document="content/admissions" data-field="steps" data-field-type="html">
           <a href="https://godspridegroupofschools.com/contact.html" class="step-card">📞 Visit or Contact Us</a>
           <a href="https://godspridegroupofschools.com/contact.html" class="step-card">📝 Get & Submit Application</a>
           <a href="https://godspridegroupofschools.com/contact.html" class="step-card">📚 Entrance Test (Primary/Secondary)</a>
@@ -264,8 +270,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -281,19 +289,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -302,6 +312,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/contact.html
+++ b/contact.html
@@ -13,16 +13,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="contact">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
     </div>
   </header>
 
@@ -40,8 +46,9 @@
 
   <div class="container">
     <section class="contact">
-      <h2>Contact Us</h2>
-      <p>If you have any questions or inquiries, feel free to reach out to us. We'd love to hear from you!</p>
+      <h2 data-document="content/contact" data-field="heading">Contact Us</h2>
+      <p data-document="content/contact" data-field="intro" data-field-type="html">If you have any questions or
+        inquiries, feel free to reach out to us. We'd love to hear from you!</p>
       <form action="https://formsubmit.co/8da530955ad70219843754c8964446b6" method="POST" class="contact-form">
         <!-- Honeypot (spam protection) -->
         <input type="text" name="_honey" style="display:none;">
@@ -75,8 +82,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -92,19 +101,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -113,6 +124,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/docs/content-audit.md
+++ b/docs/content-audit.md
@@ -1,0 +1,33 @@
+# Firebase Content Audit
+
+The table below documents every dynamic binding in the site and the Firestore location that powers it. Paths follow the `collection/doc` notation used by the Firebase Web SDK.
+
+| Page | Component | Firestore Source | Notes |
+| --- | --- | --- | --- |
+| All pages | Header logos & slogan | `settings/global` | `logos.left.url`, `logos.right.url`, `siteName`, and `tagline` feed the masthead. |
+| All pages | Footer contact block | `settings/global` | Uses `contact.email`, `contact.phone`, `address`, `social.facebook`, `social.instagram`, and `footer.copyright`. |
+| Home (`index.html`) | Intro banner | `settings/homepage` | `intro.title` and `intro.marquee`. |
+| Home | Carousel | `media/homeCarousel` collection | Ordered by `order`; each item exposes `image.url`, `caption`, `description`. |
+| Home | Announcements list | `announcements` collection | Ordered by `publishedAt desc`, limited to three cards. |
+| Home | Testimonials slider | `testimonials` collection | Ordered by `priority desc`, limited to six entries. |
+| About | Proprietor profile, mandate, vision, mission, values, entrepreneurship | `content/about` | Individual fields (`owner.*`, `mandate.*`, `vision.*`, `mission.*`, `values.*`, `entrepreneurship.*`). |
+| Admissions | Hero copy & step cards | `content/admissions` | `hero.title`, `hero.intro`, and `steps` (HTML list). |
+| Contact | Page heading & intro | `content/contact` | `heading` and `intro`. |
+| News | Page heading & intro | `content/news` | `heading`, `intro`, and `announcements.heading`, `latest.heading`. |
+| News | Featured announcements | `announcements` collection | Shared with the home page. |
+| News | Latest news cards | `news` collection | Ordered by `publishedAt desc`, up to six cards. |
+| Gallery | Section heading & description | `content/gallery` | `heading` and `intro`. |
+| Gallery | Media grid | `media/gallery` collection | Sorted by optional `order`; items require `url`, optional `caption`. |
+| Schools overview | Overview hero | `content/schools` | `overview` (HTML) for the lead copy. |
+| Schools overview | Program cards | `content/schools` | `programs` (HTML) renders card content. |
+| Nursery & Primary | Hero, overview, testimonials, contact CTA | `content/nurseryPrimary` | Fields: `hero`, `overview`, `testimonials`, `contact` (all HTML). |
+| Secondary School | Hero, overview, testimonials, contact CTA | `content/secondary` | Fields mirror the nursery/primary structure. |
+
+### Image & asset handling
+
+- Carousel and gallery components expect documents in `media/*` collections containing at minimum a `url` field. Optional metadata fields (`alt`, `caption`, `description`, `order`) enhance rendering.
+- Announcements, news, and testimonials collections may include nested `image` objects with `url`/`alt` keys and rich-text HTML (`body`) used inside the expandable panels.
+
+### Fallback behaviour
+
+Each dynamic binding preserves its initial static HTML as a fallback. If Firestore is unreachable or fields are missing, the site restores the original markup so visitors never encounter broken sections.

--- a/gallery.html
+++ b/gallery.html
@@ -13,16 +13,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="gallery">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
     </div>
   </header>
 
@@ -40,8 +46,10 @@
 
   <div class="container1">
     <section class="image-gallery">
-      <h2 class="section-title">Image Gallery</h2>
-      <div class="media-gallery">
+      <h2 class="section-title" data-document="content/gallery" data-field="heading">Image Gallery</h2>
+      <p class="section-intro" data-document="content/gallery" data-field="intro" data-field-type="html">A glimpse into
+        life at God's Pride Group of Schools—from classroom excellence to vibrant extracurricular activities.</p>
+      <div class="media-gallery" data-collection="gallery" data-collection-path="media/gallery" data-order-by="order:asc">
         <!-- Gallery Images Start -->
         <div class="media-item">
           <img src="image287.JPG" alt="Image 179" class="responsive-image">
@@ -816,8 +824,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -833,19 +843,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -854,6 +866,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/index.html
+++ b/index.html
@@ -35,16 +35,22 @@
   </script>
 </head>
 
-<body>
+<body data-page="home">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
     </div>
   </header>
 
@@ -61,7 +67,7 @@
   </nav>
 
   <section class="image-carousel">
-    <div id="myCarousel" class="carousel slide" data-ride="carousel">
+    <div id="myCarousel" class="carousel slide" data-ride="carousel" data-carousel="home">
       <ol class="carousel-indicators">
         <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
         <li data-target="#myCarousel" data-slide-to="1"></li>
@@ -95,16 +101,20 @@
   </section>
 
   <div class="container1">
-    <section class"intro1">
-      <h2 class="section-title">God's Pride Group of Schools</h2>
-      <div class="scrolling-text">The Home Of Godly Global Champions</div>
+    <section class="intro1">
+      <h2 class="section-title" data-document="settings/homepage" data-field="intro.title">God's Pride Group of Schools
+      </h2>
+      <div class="scrolling-text" data-document="settings/homepage" data-field="intro.marquee"
+        data-field-type="html">The Home Of Godly Global Champions</div>
     </section>
   </div>
   
   <div class="container">
     <section class="announcement">
-      <h2 class="section-title">Latest Announcements</h2>
-      <div class="announcement-cards">
+      <h2 class="section-title" data-document="settings/homepage" data-field="announcements.heading">Latest Announcements
+      </h2>
+      <div class="announcement-cards" data-collection="announcements" data-collection-path="announcements"
+        data-order-by="publishedAt:desc" data-limit="3">
         <div class="announcement-card">
           <img src="announcement-image1.jpeg" alt="Announcement 1">
           <h3>ADMISSIONS NOW OPEN!!!</h3>
@@ -183,8 +193,10 @@
     </section>
 
     <section class="testimonial">
-      <h2 class="section-title">What Our Students and Parents Say</h2>
-      <div class="testimonial-carousel">
+      <h2 class="section-title" data-document="settings/homepage" data-field="testimonials.heading">What Our Students and
+        Parents Say</h2>
+      <div class="testimonial-carousel" data-collection="testimonials" data-collection-path="testimonials"
+        data-order-by="priority:desc" data-limit="6">
         <div class="testimonial-card">
           <div class="testimonial-content">
             <p>"God's Pride College Ota, will nurture your child to greatness. I am a proud parent of the school. The three students I took to the school did their JAMB & WAEC once. They came out with outstanding results."</p>
@@ -342,8 +354,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -359,19 +373,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -380,6 +396,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
 </body>
 

--- a/news.html
+++ b/news.html
@@ -13,16 +13,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="news">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
     </div>
   </header>
 
@@ -39,10 +45,13 @@
   </nav>
   <div class="container">
     <section class="news">
-      <h2 class="section-title">News</h2>
+      <h2 class="section-title" data-document="content/news" data-field="heading">News</h2>
+      <p class="section-intro" data-document="content/news" data-field="intro" data-field-type="html">Stay up to date with
+        the latest milestones, celebrations, and events happening across God's Pride Group of Schools.</p>
       <article>
         <section class="announcement">
-          <div class="announcement-cards">
+          <h3 class="section-title" data-document="content/news" data-field="announcements.heading">Featured Announcements</h3>
+          <div class="announcement-cards" data-collection="announcements" data-collection-path="announcements" data-order-by="publishedAt:desc" data-limit="3">
             <div class="announcement-card">
               <img src="announcement-image1.jpeg" alt="Announcement 1">
               <h3>ADMISSIONS NOW OPEN!!!</h3>
@@ -121,56 +130,20 @@
         </section>
       </article>
       <article>
-        <h3 class="section-title">Latest News</h3>
-        <p>Date: August 28, 2024</p>
-        <section class="announcement">
-            <div class="announcement-card">
-              <img src="announcement-image2.jpeg" alt="Announcement 2">
+        <h3 class="section-title" data-document="content/news" data-field="latest.heading">Latest News</h3>
+        <div class="news-card-list" data-collection="news" data-collection-path="news" data-order-by="publishedAt:desc"
+          data-limit="6">
+          <div class="news-card">
+            <img src="announcement-image2.jpeg" alt="Announcement 2">
+            <div class="news-card-body">
               <h3>2024 Summer Splash !!!</h3>
-              <div class="scrolling-text">
-                <p><strong>🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞</strong></p>
-              </div>
-              <a href="#" class="read-more-link">Read More</a>
-              <div class="expanded-content">
-                <p><strong>🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞</strong></p>
-                <p>Empowering Kids and Teens to Explore the World of Coding and Artificial Intelligence Through Hands-on Activities and Interactive Sessions organized by DSN.</p>
-                <p><strong>Highlights:</strong></p>
-                <ul>
-                  <li>Dear Parent,</li>
-                  <br/><br/>
-                  <li>We are thrilled to invite your child to the FREE AI Career Development Event for Kids and Teens.</li>
-                  <br/><br/>
-                  <li>Event Details:</li>
-                  <br/><br/>
-                  <li>Date: Wednesday, 28th August 2024</li>
-                  <br/><br/>
-                  <li>Time: 11:00 am - 2:00 pm</li>
-                  <br/><br/>
-                  <li>Mode of Delivery: Hybrid</li>
-                  <br/><br/>
-                  <li>Venue 1: DSN AI Hub, Yaba, Lagos | ZOOM & YouTube</li>
-                  <br/><br/>
-                  <li>Venue 2: God’s Pride College, Ali Ishiba, Sango Ota, Ogun State | ZOOM & YouTube</li>
-                  <br/><br/>
-                  <li>This event is designed to inspire and engage young minds, introducing them to the basics of Coding and Artificial Intelligence through hands-on activities and interactive sessions.</li>
-                  <br/><br/>
-                  <li>Don’t miss out on this fantastic opportunity to unlock your child's hidden potential with the power of AI! Give them the opportunity to explore the exciting world of Artificial Intelligence, discover a new passion, and potentially pave the way for a future career in this dynamic field.</li>
-                  <br/><br/>
-                  <li>Click here to book a seat for your child: <a href="https://bit.ly/DSNAICareerDay24">https://bit.ly/DSNAICareerDay24</a></li>
-                  <br/><br/>
-                  <li>We look forward to seeing your child embark on this exciting journey into the world of AI.</li>
-                  <br/><br/>
-                  <li>God’s Pride Schools care.</li>
-                </ul>
-                <p>Don't miss out on this fantastic opportunity to make your summer unforgettable! Join us at God's
-                  Pride Group of Schools and discover a world of learning, fun, and personal growth.</p>
-              </div>
-            </div>
+              <p>🌞 Unlock Your Child’s Future with AI: Join Our Free AI Career Development Event! 🌞</p>
+              <p class="news-date">August 28, 2024</p>
+              <a href="https://bit.ly/DSNAICareerDay24" class="news-read-more">Read More</a>
             </div>
           </div>
-        </section>
+        </div>
       </article>
-      <!-- Add more articles as needed -->
     </section>
     <!-- Other content for the News page -->
   </div>
@@ -178,8 +151,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -198,19 +173,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -219,6 +196,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/nursery_primary.html
+++ b/nursery_primary.html
@@ -13,14 +13,23 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 
-<body>
+<body data-page="nurseryPrimary">
   <header>
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo">
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG">
     </div>
-    <h1>GOD'S PRIDE GROUP OF SCHOOLS
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
-    </h1>
+    <div class="header-title">
+      <h1>
+        <span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span>
+      </h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
+    </div>
+    <div class="logo">
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG">
+    </div>
   </header>
 
   <nav>
@@ -35,7 +44,7 @@
       <li><a href="contact.html">Contact</a></li>
     </ul>
   </nav>
-  <section class="image-carousel">
+  <section class="image-carousel" data-document="content/nurseryPrimary" data-field="hero" data-field-type="html">
     <div id="myCarousel" class="carousel slide" data-ride="carousel">
       <ol class="carousel-indicators">
         <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
@@ -73,12 +82,14 @@
 
   <div class="container">
 
-    <section class="announcement">
+    <section class="announcement" data-document="content/nurseryPrimary" data-field="overview"
+      data-field-type="html">
       <h2>GOD'S PRIDE NURSERY AND PRIMARY  SCHOOL</h2>
       <p>The Home Of Godly Global Champions</p>
     </section>
    
-    <section class="testimonial">
+    <section class="testimonial" data-document="content/nurseryPrimary" data-field="testimonials"
+      data-field-type="html">
       <h2>What Our Students and Parent Say</h2>
       <div class="testimonial-card">
         <div class="testimonial-content">
@@ -124,7 +135,8 @@
     </section>
     
 
-  <section class="contact">
+  <section class="contact" data-document="content/nurseryPrimary" data-field="contact"
+    data-field-type="html">
     <h2>Contact Us</h2>
     <div class="contact-form">
       <form action="https://formsubmit.co/8da530955ad70219843754c8964446b6" method="POST">
@@ -159,8 +171,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -177,19 +191,21 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a>
           </li>
-          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA=="><img src="instagram-icon.png"
-                alt="Instagram"></a></li>
+          <li><a href="https://instagram.com/godsprideschool?igshid=MzRlODBiNWFlZA==" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -198,6 +214,8 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
   
 </body>

--- a/schools.html
+++ b/schools.html
@@ -11,17 +11,20 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" />
 </head>
 
-<body>
+<body data-page="schools">
   <header class="school-header d-flex justify-content-between align-items-center px-4 py-3">
     <div class="logo">
-      <img src="logo_left.JPG" alt="Left Logo" />
+      <img src="logo_left.JPG" alt="Left Logo" data-document="settings/global" data-field="logos.left.url"
+        data-attr="src" data-fallback="logo_left.JPG" />
     </div>
     <div class="text-center">
-      <h1>GOD'S PRIDE GROUP OF SCHOOLS</h1>
-      <p class="slogan">Building Spiritual, Moral and Academic Excellence on a Firm Foundation</p>
+      <h1><span data-document="settings/global" data-field="siteName">GOD'S PRIDE GROUP OF SCHOOLS</span></h1>
+      <p class="slogan" data-document="settings/global" data-field="tagline">Building Spiritual, Moral and Academic
+        Excellence on a Firm Foundation</p>
     </div>
     <div class="logo">
-      <img src="logo_right.JPG" alt="Right Logo" />
+      <img src="logo_right.JPG" alt="Right Logo" data-document="settings/global" data-field="logos.right.url"
+        data-attr="src" data-fallback="logo_right.JPG" />
     </div>
   </header>
 
@@ -38,8 +41,8 @@
   </nav>
 
   <main class="container my-5">
-    <!-- Academics Overview -->
-    <section class="academics-overview text-center mb-5">
+    <section class="academics-overview text-center mb-5" data-document="content/schools" data-field="overview"
+      data-field-type="html">
       <h2 class="section-title">Our Academic Program</h2>
       <p class="overview-text mx-auto" style="max-width: 800px;">
         Our academic program is designed to develop <strong>critical thinking</strong>,
@@ -48,8 +51,7 @@
       </p>
     </section>
 
-    <!-- Section Breakdowns as Cards -->
-    <section class="academics-breakdown">
+    <section class="academics-breakdown" data-document="content/schools" data-field="programs" data-field-type="html">
       <div class="cards-grid">
         <div class="card">
           <h3>Nursery School</h3>
@@ -71,8 +73,10 @@
     <div class="footer-content">
       <div class="footer-section">
         <h3>Contact Us</h3>
-        <p>Email: godsprideschools2004@gmail.com</p>
-        <p>Phone: +234-9073366566, +234-8023516321</p>
+        <p>Email: <span data-document="settings/global" data-field="contact.email">godsprideschools2004@gmail.com</span>
+        </p>
+        <p>Phone: <span data-document="settings/global" data-field="contact.phone">+234-9073366566, +234-8023516321</span>
+        </p>
       </div>
       <div class="footer-section">
         <h3>Quick Links</h3>
@@ -88,17 +92,20 @@
       <div class="footer-section">
         <h3>Follow Us</h3>
         <ul class="social-links">
-          <li><a href="https://www.facebook.com/godspridecollege2004"><img src="facebook-icon.png" alt="Facebook"></a></li>
-          <li><a href="https://instagram.com/godsprideschool"><img src="instagram-icon.png" alt="Instagram"></a></li>
+          <li><a href="https://www.facebook.com/godspridecollege2004" data-document="settings/global"
+              data-field="social.facebook" data-attr="href"><img src="facebook-icon.png" alt="Facebook"></a></li>
+          <li><a href="https://instagram.com/godsprideschool" data-document="settings/global"
+              data-field="social.instagram" data-attr="href"><img src="instagram-icon.png" alt="Instagram"></a></li>
         </ul>
       </div>
       <div class="footer-section">
         <h3>Our Address</h3>
-        <p>13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba, Sango Ota, Ogun State.</p>
+        <p data-document="settings/global" data-field="address">13/15 Olugbemi Street, Off Faith Chapel, Ali-Ishiba,
+          Sango Ota, Ogun State.</p>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 MEGSOW. All Rights Reserved.</p>
+      <p data-document="settings/global" data-field="footer.copyright">&copy; 2025 MEGSOW. All Rights Reserved.</p>
     </div>
   </footer>
 
@@ -107,6 +114,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="src/main.js"></script>
   <script src="script.js"></script>
 </body>
 

--- a/script.js
+++ b/script.js
@@ -1,104 +1,108 @@
 // Handle form submission
-document.getElementById("contact-form")?.addEventListener("submit", function(event) {
+const contactForm = document.getElementById('contact-form');
+if (contactForm) {
+  contactForm.addEventListener('submit', event => {
     event.preventDefault();
-  
-    // Fetch form data
-    const name = document.getElementById("name").value;
-    const email = document.getElementById("email").value;
-    const message = document.getElementById("message").value;
-  
-    // Log form data
-    console.log("Name:", name);
-    console.log("Email:", email);
-    console.log("Message:", message);
-  
-    // Optionally, display a success message or reset the form
-    alert("Form submitted successfully!");
-    this.reset(); // Reset form directly using 'this'
-});
 
-// Handle navigation toggle for mobile view
-document.addEventListener('DOMContentLoaded', function () {
-    const navToggle = document.querySelector('.nav-toggle');
-    const navMenu = document.querySelector('.nav-menu');
+    const formData = new FormData(contactForm);
+    console.log('Name:', formData.get('name'));
+    console.log('Email:', formData.get('email'));
+    console.log('Message:', formData.get('message'));
 
-    if (navToggle && navMenu) {
-        navToggle.addEventListener('click', function () {
-            navMenu.classList.toggle('active');
-        });
-    }
-});
+    alert('Form submitted successfully!');
+    contactForm.reset();
+  });
+}
 
-// Animate testimonials when they come into view
-document.addEventListener('DOMContentLoaded', function () {
-    const testimonialCards = document.querySelectorAll('.testimonial-card');
-    
-    function isInViewport(element) {
-        const rect = element.getBoundingClientRect();
-        return (
-            rect.top >= 0 &&
-            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
-        );
-    }
-  
-    function animateTestimonials() {
-        testimonialCards.forEach(card => {
-            if (isInViewport(card)) {
-                card.classList.add('show');
-            }
-        });
-    }
-  
-    window.addEventListener('scroll', animateTestimonials);
-    animateTestimonials(); // Run on page load
-});
-
-// Animate announcement cards when they come into view and handle "Read More" functionality
-document.addEventListener('DOMContentLoaded', function () {
-    const announcementCards = document.querySelectorAll('.announcement-card');
-    const readMoreLinks = document.querySelectorAll('.read-more-link');
-  
-    function isInViewport(element) {
-        const rect = element.getBoundingClientRect();
-        return (
-            rect.top >= 0 &&
-            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
-        );
-    }
-  
-    function animateAnnouncementCards() {
-        announcementCards.forEach(card => {
-            if (isInViewport(card)) {
-                card.classList.add('show');
-            }
-        });
-    }
-  
-    window.addEventListener('scroll', animateAnnouncementCards);
-    animateAnnouncementCards(); // Run on page load
-  
-    // Handle "Read More" functionality
-    readMoreLinks.forEach(link => {
-        link.addEventListener('click', function (event) {
-            event.preventDefault();
-            const card = this.closest('.announcement-card');
-            const expandedContent = card.querySelector('.expanded-content');
-
-            if (expandedContent) {
-                expandedContent.classList.toggle('show');
-                this.textContent = expandedContent.classList.contains('show') ? 'Read Less' : 'Read More';
-            }
-        });
+function initNavToggle() {
+  const navToggle = document.querySelector('.nav-toggle');
+  const navMenu = document.querySelector('.nav-menu');
+  if (navToggle && navMenu) {
+    navToggle.addEventListener('click', () => {
+      navMenu.classList.toggle('active');
     });
+  }
+}
+
+function setupRevealAnimation(selector, revealClass) {
+  const elements = Array.from(document.querySelectorAll(selector));
+  if (!elements.length) {
+    return;
+  }
+  function isInViewport(element) {
+    const rect = element.getBoundingClientRect();
+    return rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
+  }
+  function animate() {
+    elements.forEach(element => {
+      if (isInViewport(element)) {
+        element.classList.add(revealClass);
+      }
+    });
+  }
+  window.addEventListener('scroll', animate);
+  animate();
+}
+
+function initReadMoreDelegation() {
+  document.addEventListener('click', event => {
+    const trigger = event.target.closest('.read-more-link');
+    if (!trigger) {
+      return;
+    }
+    event.preventDefault();
+    const card = trigger.closest('.announcement-card');
+    const expandedContent = card?.querySelector('.expanded-content');
+    if (!expandedContent) {
+      return;
+    }
+    expandedContent.classList.toggle('show');
+    trigger.textContent = expandedContent.classList.contains('show') ? 'Read Less' : 'Read More';
+  });
+}
+
+function initialiseTestimonialCarousel() {
+  if (typeof window.$ !== 'function') {
+    return;
+  }
+  const $carousel = window.$('.testimonial-carousel');
+  if (!$carousel.length) {
+    return;
+  }
+  if ($carousel.hasClass('slick-initialized')) {
+    $carousel.slick('unslick');
+  }
+  $carousel.slick({
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 2,
+    slidesToScroll: 1,
+    responsive: [
+      {
+        breakpoint: 768,
+        settings: {
+          slidesToShow: 1,
+        },
+      },
+    ],
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initNavToggle();
+  setupRevealAnimation('.testimonial-card', 'show');
+  setupRevealAnimation('.announcement-card', 'show');
+  initReadMoreDelegation();
+  initialiseTestimonialCarousel();
 });
 
-// Initialize Bootstrap carousel
-$(document).ready(function () {
-    if ($('#myCarousel').length > 0) {
-        $('#myCarousel').carousel({
-            interval: 5000,
-            pause: 'hover',
-            wrap: true
-        });
-    }
+document.addEventListener('collection:hydrated', event => {
+  if (event.detail?.key === 'announcements') {
+    setupRevealAnimation('.announcement-card', 'show');
+  }
+  if (event.detail?.key === 'testimonials') {
+    initialiseTestimonialCarousel();
+    setupRevealAnimation('.testimonial-card', 'show');
+  }
 });

--- a/src/firebase/app.js
+++ b/src/firebase/app.js
@@ -1,0 +1,41 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+
+let cachedApp = null;
+
+function loadConfig() {
+  if (typeof window === 'undefined') {
+    throw new Error('Firebase config is only available in the browser');
+  }
+
+  if (window.__FIREBASE_CONFIG__) {
+    return window.__FIREBASE_CONFIG__;
+  }
+
+  if (window.firebaseConfig) {
+    return window.firebaseConfig;
+  }
+
+  throw new Error(
+    'Firebase configuration is missing. Expose window.__FIREBASE_CONFIG__ before loading src/main.js or provide a global window.firebaseConfig object.'
+  );
+}
+
+export function getFirebaseApp() {
+  if (cachedApp) {
+    return cachedApp;
+  }
+
+  const config = loadConfig();
+
+  if (!config || typeof config !== 'object') {
+    throw new Error('Firebase configuration must be an object.');
+  }
+
+  if (getApps().length) {
+    cachedApp = getApps()[0];
+    return cachedApp;
+  }
+
+  cachedApp = initializeApp(config);
+  return cachedApp;
+}

--- a/src/firebase/config.sample.js
+++ b/src/firebase/config.sample.js
@@ -1,0 +1,12 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};
+
+// Copy this file to src/firebase/config.js and replace the placeholder values
+// with the credentials from your Firebase project. The file is ignored by git
+// to protect secrets.

--- a/src/firebase/firestore.js
+++ b/src/firebase/firestore.js
@@ -1,0 +1,35 @@
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  orderBy,
+  limit,
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+import { getFirebaseApp } from './app.js';
+
+let cachedDb = null;
+
+export function getDb() {
+  if (cachedDb) {
+    return cachedDb;
+  }
+
+  const app = getFirebaseApp();
+  cachedDb = getFirestore(app);
+  return cachedDb;
+}
+
+export {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  orderBy,
+  limit,
+};

--- a/src/hooks/useFirestore.js
+++ b/src/hooks/useFirestore.js
@@ -1,0 +1,160 @@
+import {
+  getDb,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  orderBy,
+  limit,
+} from '../firebase/firestore.js';
+
+const DEFAULT_TTL = 5 * 60 * 1000;
+
+const documentCache = new Map();
+const collectionCache = new Map();
+
+function createCacheKey(path, options = {}) {
+  return `${path}|${JSON.stringify(options)}`;
+}
+
+function getDocSegments(path) {
+  const segments = path.split('/').map(segment => segment.trim()).filter(Boolean);
+  if (segments.length < 2 || segments.length % 2 !== 0) {
+    throw new Error(`Invalid document path: ${path}`);
+  }
+  return segments;
+}
+
+function getCollectionSegments(path) {
+  const segments = path.split('/').map(segment => segment.trim()).filter(Boolean);
+  if (segments.length === 0) {
+    throw new Error(`Invalid collection path: ${path}`);
+  }
+  return segments;
+}
+
+function normaliseOrderBy(order) {
+  if (!order) {
+    return [];
+  }
+  if (Array.isArray(order) && typeof order[0] === 'string') {
+    return [order];
+  }
+  if (Array.isArray(order)) {
+    return order;
+  }
+  throw new Error('orderBy must be an array.');
+}
+
+async function runQuery(path, options = {}) {
+  const db = getDb();
+  const segments = getCollectionSegments(path);
+  let ref = collection(db, ...segments);
+  const constraints = [];
+
+  normaliseOrderBy(options.orderBy).forEach(([field, direction]) => {
+    constraints.push(orderBy(field, direction));
+  });
+
+  if (options.limit) {
+    constraints.push(limit(options.limit));
+  }
+
+  if (constraints.length) {
+    ref = query(ref, ...constraints);
+  }
+
+  const snapshot = await getDocs(ref);
+  return snapshot.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+export async function useDocument(path, { ttl = DEFAULT_TTL, fallback = null } = {}) {
+  const cached = documentCache.get(path);
+  if (cached && Date.now() - cached.timestamp < ttl) {
+    return { data: cached.data, fromCache: true, error: null };
+  }
+
+  try {
+    const db = getDb();
+    const segments = getDocSegments(path);
+    const ref = doc(db, ...segments);
+    const snapshot = await getDoc(ref);
+    if (!snapshot.exists()) {
+      throw new Error(`Document not found at ${path}`);
+    }
+    const data = snapshot.data();
+    documentCache.set(path, { data, timestamp: Date.now() });
+    return { data, fromCache: false, error: null };
+  } catch (error) {
+    if (fallback !== null && fallback !== undefined) {
+      return { data: fallback, fromCache: false, error };
+    }
+    return { data: null, fromCache: false, error };
+  }
+}
+
+export async function useCollection(path, { ttl = DEFAULT_TTL, fallback = [] , orderBy: order, limit: limitValue } = {}) {
+  const cacheKey = createCacheKey(path, { order, limit: limitValue });
+  const cached = collectionCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < ttl) {
+    return { data: cached.data, fromCache: true, error: null };
+  }
+
+  try {
+    const data = await runQuery(path, { orderBy: order, limit: limitValue });
+    collectionCache.set(cacheKey, { data, timestamp: Date.now() });
+    return { data, fromCache: false, error: null };
+  } catch (error) {
+    if (fallback) {
+      return { data: fallback, fromCache: false, error };
+    }
+    return { data: [], fromCache: false, error };
+  }
+}
+
+export function subscribeDocument(path, callback) {
+  try {
+    const db = getDb();
+    const segments = getDocSegments(path);
+    const ref = doc(db, ...segments);
+    return onSnapshot(ref, snapshot => {
+      callback(snapshot.exists() ? snapshot.data() : null);
+    });
+  } catch (error) {
+    console.warn(`subscribeDocument failed for ${path}:`, error);
+    callback(null, error);
+    return () => {};
+  }
+}
+
+export function subscribeCollection(path, callback, options = {}) {
+  try {
+    const db = getDb();
+    const segments = getCollectionSegments(path);
+    let ref = collection(db, ...segments);
+    const constraints = [];
+    normaliseOrderBy(options.orderBy).forEach(([field, direction]) => {
+      constraints.push(orderBy(field, direction));
+    });
+    if (options.limit) {
+      constraints.push(limit(options.limit));
+    }
+    if (constraints.length) {
+      ref = query(ref, ...constraints);
+    }
+    return onSnapshot(ref, snapshot => {
+      callback(snapshot.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() })), null);
+    });
+  } catch (error) {
+    console.warn(`subscribeCollection failed for ${path}:`, error);
+    callback([], error);
+    return () => {};
+  }
+}
+
+export function clearFirestoreCache() {
+  documentCache.clear();
+  collectionCache.clear();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,55 @@
+import { hydrateDocumentFields, hydrateCollections } from './utils/bindings.js';
+import {
+  renderAnnouncementCard,
+  renderTestimonialCard,
+  renderNewsCard,
+  renderGalleryItem,
+} from './utils/renderers.js';
+
+const pageName = document.body?.dataset?.page || null;
+
+const collectionRenderers = {
+  default: {},
+  home: {
+    announcements: renderAnnouncementCard,
+    testimonials: renderTestimonialCard,
+  },
+  news: {
+    announcements: renderAnnouncementCard,
+    news: renderNewsCard,
+  },
+  gallery: {
+    gallery: renderGalleryItem,
+  },
+};
+
+const pageModules = {
+  home: () => import('./pages/home.js'),
+  about: () => import('./pages/about.js'),
+  admission: () => import('./pages/admission.js'),
+  contact: () => import('./pages/contact.js'),
+  news: () => import('./pages/news.js'),
+  gallery: () => import('./pages/gallery.js'),
+  schools: () => import('./pages/schools.js'),
+  nurseryPrimary: () => import('./pages/nurseryPrimary.js'),
+  secondary: () => import('./pages/secondary.js'),
+};
+
+async function bootstrap() {
+  await hydrateDocumentFields();
+  const renderers = { ...(collectionRenderers.default || {}), ...(collectionRenderers[pageName] || {}) };
+  const collectionData = await hydrateCollections(renderers);
+
+  if (pageName && pageModules[pageName]) {
+    try {
+      const module = await pageModules[pageName]();
+      if (module?.renderPage) {
+        await module.renderPage({ collections: collectionData });
+      }
+    } catch (error) {
+      console.warn(`Failed to load page module for ${pageName}:`, error);
+    }
+  }
+}
+
+bootstrap();

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/admission.js
+++ b/src/pages/admission.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/gallery.js
+++ b/src/pages/gallery.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,0 +1,79 @@
+import { useCollection } from '../hooks/useFirestore.js';
+import { setLoadingHTML, restoreHTMLFallback } from '../utils/dom.js';
+import { renderCarouselSlide, renderCarouselIndicator } from '../utils/renderers.js';
+
+async function hydrateCarousel() {
+  const carousel = document.querySelector('[data-carousel="home"]');
+  if (!carousel) {
+    return;
+  }
+  const inner = carousel.querySelector('.carousel-inner');
+  const indicators = carousel.querySelector('.carousel-indicators');
+  if (!inner) {
+    return;
+  }
+
+  setLoadingHTML(inner);
+  if (indicators) {
+    setLoadingHTML(indicators);
+  }
+
+  const { data, error } = await useCollection('media/homeCarousel', {
+    orderBy: ['order', 'asc'],
+  });
+
+  if (error || !data.length) {
+    restoreHTMLFallback(inner);
+    if (indicators) {
+      restoreHTMLFallback(indicators);
+    }
+    return;
+  }
+
+  inner.innerHTML = '';
+  if (indicators) {
+    indicators.innerHTML = '';
+  }
+
+  data.forEach((item, index) => {
+    inner.appendChild(renderCarouselSlide(item, { active: index === 0 }));
+    if (indicators) {
+      indicators.appendChild(renderCarouselIndicator(index, { active: index === 0 }));
+    }
+  });
+}
+
+function reinitialiseTestimonialCarousel() {
+  const container = document.querySelector('.testimonial-carousel');
+  if (!container || typeof window.$ !== 'function') {
+    return;
+  }
+  const $container = window.$(container);
+  if ($container.hasClass('slick-initialized')) {
+    $container.slick('unslick');
+  }
+  $container.slick({
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 2,
+    slidesToScroll: 1,
+    responsive: [
+      {
+        breakpoint: 768,
+        settings: {
+          slidesToShow: 1,
+        },
+      },
+    ],
+  });
+}
+
+export async function renderPage() {
+  await hydrateCarousel();
+  document.addEventListener('collection:hydrated', event => {
+    if (event.detail?.key === 'testimonials') {
+      reinitialiseTestimonialCarousel();
+    }
+  });
+}

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/nurseryPrimary.js
+++ b/src/pages/nurseryPrimary.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/schools.js
+++ b/src/pages/schools.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/pages/secondary.js
+++ b/src/pages/secondary.js
@@ -1,0 +1,3 @@
+export async function renderPage() {
+  // This page currently relies on shared document/collection hydration.
+}

--- a/src/utils/bindings.js
+++ b/src/utils/bindings.js
@@ -1,0 +1,145 @@
+import { useDocument, useCollection } from '../hooks/useFirestore.js';
+import { getNestedValue, setNestedText } from './object.js';
+import {
+  setLoadingText,
+  setLoadingHTML,
+  restoreTextFallback,
+  restoreHTMLFallback,
+  cacheHtmlFallback,
+  cacheTextFallback,
+} from './dom.js';
+
+function parseOrderBy(value) {
+  if (!value) {
+    return undefined;
+  }
+  return value.split(',').map(token => {
+    const [field, direction] = token.split(':').map(part => part.trim());
+    return [field, direction || 'asc'];
+  });
+}
+
+export async function hydrateDocumentFields() {
+  const elements = Array.from(document.querySelectorAll('[data-document][data-field]'));
+  if (!elements.length) {
+    return;
+  }
+
+  const groups = elements.reduce((acc, element) => {
+    const docPath = element.dataset.document;
+    if (!docPath) {
+      return acc;
+    }
+    if (!acc.has(docPath)) {
+      acc.set(docPath, []);
+    }
+    acc.get(docPath).push(element);
+    return acc;
+  }, new Map());
+
+  await Promise.all(
+    Array.from(groups.entries()).map(async ([docPath, nodes]) => {
+      nodes.forEach(node => {
+        const type = node.dataset.fieldType;
+        const attr = node.dataset.attr;
+        if (attr) {
+          if (!node.dataset.attrFallback) {
+            node.dataset.attrFallback = node.getAttribute(attr) || '';
+          }
+        } else if (type === 'html') {
+          setLoadingHTML(node);
+        } else {
+          setLoadingText(node);
+        }
+      });
+
+      const { data, error } = await useDocument(docPath);
+
+      nodes.forEach(node => {
+        const type = node.dataset.fieldType;
+        const field = node.dataset.field;
+        const attr = node.dataset.attr;
+        const fallback = node.dataset.fallback;
+        const defaultValue = fallback !== undefined ? fallback : null;
+
+        if (!data || error) {
+          if (attr) {
+            node.setAttribute(attr, node.dataset.attrFallback || '');
+          } else if (type === 'html') {
+            restoreHTMLFallback(node);
+          } else {
+            restoreTextFallback(node);
+          }
+          return;
+        }
+
+        const value = getNestedValue(data, field);
+        if (attr) {
+          const attrValue = value ?? defaultValue ?? node.dataset.attrFallback;
+          if (attrValue !== undefined && attrValue !== null) {
+            node.setAttribute(attr, attrValue);
+          }
+        } else if (type === 'html') {
+          if (value !== undefined && value !== null) {
+            cacheHtmlFallback(node);
+            node.innerHTML = value;
+          } else {
+            restoreHTMLFallback(node);
+          }
+        } else {
+          if (value !== undefined && value !== null) {
+            cacheTextFallback(node);
+            setNestedText(node, value);
+          } else {
+            restoreTextFallback(node);
+          }
+        }
+      });
+    })
+  );
+}
+
+export async function hydrateCollections(renderers = {}) {
+  const containers = Array.from(document.querySelectorAll('[data-collection]'));
+  if (!containers.length) {
+    return {};
+  }
+  const results = {};
+
+  await Promise.all(
+    containers.map(async container => {
+      const key = container.dataset.collection;
+      const path = container.dataset.collectionPath || key;
+      const limitValue = container.dataset.limit ? Number(container.dataset.limit) : undefined;
+      const orderByValue = parseOrderBy(container.dataset.orderBy);
+      setLoadingHTML(container);
+
+      const { data, error } = await useCollection(path, {
+        orderBy: orderByValue,
+        limit: limitValue,
+      });
+
+      if (error || !data.length || !renderers[key]) {
+        restoreHTMLFallback(container);
+        return;
+      }
+
+      const renderer = renderers[key];
+      container.innerHTML = '';
+      data.forEach((item, index) => {
+        const node = renderer(item, { index });
+        if (node) {
+          container.appendChild(node);
+        }
+      });
+      results[key] = data;
+      document.dispatchEvent(
+        new CustomEvent('collection:hydrated', {
+          detail: { key, data, container },
+        })
+      );
+    })
+  );
+
+  return results;
+}

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,0 +1,52 @@
+const textFallback = new WeakMap();
+const htmlFallback = new WeakMap();
+
+export function setLoadingText(element, placeholder = 'Loading…') {
+  if (!(element instanceof Element)) {
+    return;
+  }
+  if (!textFallback.has(element)) {
+    textFallback.set(element, element.textContent);
+  }
+  element.textContent = placeholder;
+}
+
+export function setLoadingHTML(element, placeholder = '<p class="loading">Loading…</p>') {
+  if (!(element instanceof Element)) {
+    return;
+  }
+  if (!htmlFallback.has(element)) {
+    htmlFallback.set(element, element.innerHTML);
+  }
+  element.innerHTML = placeholder;
+}
+
+export function restoreTextFallback(element) {
+  if (textFallback.has(element)) {
+    element.textContent = textFallback.get(element);
+  }
+}
+
+export function restoreHTMLFallback(element) {
+  if (htmlFallback.has(element)) {
+    element.innerHTML = htmlFallback.get(element);
+  }
+}
+
+export function cacheHtmlFallback(element) {
+  if (!(element instanceof Element)) {
+    return;
+  }
+  if (!htmlFallback.has(element)) {
+    htmlFallback.set(element, element.innerHTML);
+  }
+}
+
+export function cacheTextFallback(element) {
+  if (!(element instanceof Element)) {
+    return;
+  }
+  if (!textFallback.has(element)) {
+    textFallback.set(element, element.textContent);
+  }
+}

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,0 +1,25 @@
+export function getNestedValue(object, path) {
+  if (!object || !path) {
+    return undefined;
+  }
+  return path.split('.').reduce((value, key) => {
+    if (value && Object.prototype.hasOwnProperty.call(value, key)) {
+      return value[key];
+    }
+    return undefined;
+  }, object);
+}
+
+export function setNestedText(element, value, { html = false } = {}) {
+  if (!(element instanceof Element)) {
+    return;
+  }
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (html) {
+    element.innerHTML = value;
+  } else {
+    element.textContent = value;
+  }
+}

--- a/src/utils/renderers.js
+++ b/src/utils/renderers.js
@@ -1,0 +1,127 @@
+function createElement(tag, className, { text, html } = {}) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (html !== undefined) {
+    element.innerHTML = html;
+  } else if (text !== undefined) {
+    element.textContent = text;
+  }
+  return element;
+}
+
+export function renderAnnouncementCard(item) {
+  const card = createElement('div', 'announcement-card');
+
+  if (item.image?.url) {
+    const img = document.createElement('img');
+    img.src = item.image.url;
+    img.alt = item.image.alt || item.title || 'Announcement';
+    card.appendChild(img);
+  }
+
+  if (item.title) {
+    card.appendChild(createElement('h3', null, { text: item.title }));
+  }
+
+  const scrolling = createElement('div', 'scrolling-text');
+  const strongText = item.summary || '';
+  const summary = createElement('p', null, { html: `<strong>${strongText}</strong>` });
+  scrolling.appendChild(summary);
+  card.appendChild(scrolling);
+
+  const readMore = createElement('a', 'read-more-link', { text: 'Read More' });
+  readMore.href = '#';
+  card.appendChild(readMore);
+
+  const expanded = createElement('div', 'expanded-content', {
+    html: item.body || '',
+  });
+  card.appendChild(expanded);
+
+  return card;
+}
+
+export function renderTestimonialCard(item) {
+  const card = createElement('div', 'testimonial-card');
+  const content = createElement('div', 'testimonial-content');
+  if (item.quote) {
+    content.appendChild(createElement('p', null, { text: item.quote }));
+  }
+  if (item.author) {
+    content.appendChild(createElement('cite', null, { text: item.author }));
+  }
+  card.appendChild(content);
+  return card;
+}
+
+export function renderNewsCard(item) {
+  const card = createElement('div', 'news-card');
+  if (item.image?.url) {
+    const img = document.createElement('img');
+    img.src = item.image.url;
+    img.alt = item.image.alt || item.title || 'News image';
+    card.appendChild(img);
+  }
+  const body = createElement('div', 'news-card-body');
+  if (item.title) {
+    body.appendChild(createElement('h3', null, { text: item.title }));
+  }
+  if (item.summary) {
+    body.appendChild(createElement('p', null, { text: item.summary }));
+  }
+  if (item.publishedAt) {
+    const date = new Date(item.publishedAt.seconds ? item.publishedAt.seconds * 1000 : item.publishedAt);
+    if (!Number.isNaN(date.getTime())) {
+      body.appendChild(createElement('p', 'news-date', { text: date.toLocaleDateString() }));
+    }
+  }
+  if (item.body) {
+    const link = createElement('a', 'news-read-more', { text: 'Read More' });
+    link.href = item.link || '#';
+    body.appendChild(link);
+  }
+  card.appendChild(body);
+  return card;
+}
+
+export function renderGalleryItem(item) {
+  const wrapper = createElement('div', 'media-item');
+  const img = document.createElement('img');
+  img.loading = 'lazy';
+  img.src = item.url || item.image?.url || '';
+  img.alt = item.alt || item.caption || 'Gallery image';
+  img.className = 'responsive-image';
+  wrapper.appendChild(img);
+  if (item.caption) {
+    wrapper.appendChild(createElement('p', 'media-caption', { text: item.caption }));
+  }
+  return wrapper;
+}
+
+export function renderCarouselSlide(item, { active } = {}) {
+  const slide = createElement('div', `carousel-item${active ? ' active' : ''}`);
+  const img = document.createElement('img');
+  img.className = 'd-block w-100';
+  img.src = item.url || item.image?.url || '';
+  img.alt = item.alt || item.caption || 'Carousel slide';
+  slide.appendChild(img);
+  if (item.caption || item.description) {
+    const caption = createElement('div', 'carousel-caption', {
+      html: `<h5>${item.caption || ''}</h5><p>${item.description || ''}</p>`,
+    });
+    slide.appendChild(caption);
+  }
+  return slide;
+}
+
+export function renderCarouselIndicator(index, { active } = {}) {
+  const li = document.createElement('li');
+  li.setAttribute('data-target', '#myCarousel');
+  li.setAttribute('data-slide-to', index.toString());
+  if (active) {
+    li.classList.add('active');
+  }
+  return li;
+}


### PR DESCRIPTION
## Summary
- add reusable Firestore helpers plus DOM binding utilities for document and collection hydration
- annotate pages with data attributes, load firebase-config.js, and hydrate announcements, testimonials, carousels, and galleries from Firestore
- document the publishing workflow and content sources in a new README and content audit

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e14e7dd28c832d9ee0c5b608fb229e