### PR TITLE
Add admin login entry point and prefill credentials

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
       <li><a href="gallery.html">Gallery</a></li>
       <li><a href="news.html">News</a></li>
       <li><a href="contact.html">Contact</a></li>
+      <li class="admin-login"><a class="admin-login-button" href="admin/index.html">Admin Login</a></li>
     </ul>
   </nav>
 

--- a/src/admin/views/login.js
+++ b/src/admin/views/login.js
@@ -1,5 +1,8 @@
 import { signInWithEmail, signInWithGoogle } from "../../firebase/config.js";
 
+const DEFAULT_ADMIN_EMAIL = "admin@godspridegroupofschools.com";
+const DEFAULT_ADMIN_PASSWORD = "gpnps2003@megsow";
+
 export function renderLoginView(root, { onSuccess }) {
   root.innerHTML = "";
 
@@ -14,6 +17,11 @@ export function renderLoginView(root, { onSuccess }) {
   description.textContent =
     "Sign in with an administrator account to manage site copy and media metadata.";
 
+  const credentialsNote = document.createElement("p");
+  credentialsNote.className = "helper-text";
+  credentialsNote.textContent =
+    "Default admin credentials are pre-filled below for convenience.";
+
   const form = document.createElement("form");
   form.noValidate = true;
 
@@ -21,7 +29,7 @@ export function renderLoginView(root, { onSuccess }) {
     label: "Email",
     type: "email",
     id: "admin-email",
-    placeholder: "admin@example.com",
+    placeholder: DEFAULT_ADMIN_EMAIL,
     autocomplete: "email"
   });
 
@@ -48,7 +56,10 @@ export function renderLoginView(root, { onSuccess }) {
 
   form.append(emailField.field, passwordField.field, submitButton);
 
-  card.append(title, description, form, googleButton, status);
+  emailField.input.value = DEFAULT_ADMIN_EMAIL;
+  passwordField.input.value = DEFAULT_ADMIN_PASSWORD;
+
+  card.append(title, description, credentialsNote, form, googleButton, status);
   root.append(card);
 
   let isSubmitting = false;

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,19 @@ nav ul li a:hover {
   border-radius: 5px;
 }
 
+nav ul li.admin-login a {
+  border: 1px solid #ffffff;
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 6px 16px;
+}
+
+nav ul li.admin-login a:hover {
+  background-color: #ffffff;
+  color: #267026;
+  border-radius: 999px;
+}
+
 .nav-toggle {
   display: none;
   background: none;


### PR DESCRIPTION
## Summary
- add an Admin Login shortcut to the main site navigation
- style the navigation link so it stands out as a call-to-action
- pre-fill the admin portal login form with the provided default credentials and helper text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1578ae610832d97d78a8aff1e64cd